### PR TITLE
Fix for advance directive template urls

### DIFF
--- a/src/lib/resource-templates/AdvanceDirective.svelte
+++ b/src/lib/resource-templates/AdvanceDirective.svelte
@@ -1,4 +1,5 @@
 <script>
+  import { base64toBlob } from '$lib/util';
   export let resource; // Define a prop to pass the data to the component
 </script>
 
@@ -69,8 +70,10 @@ Text:
 <br/>
 {#if resource.content}
   {#each resource.content as content}
-    {#if content.attachment && content.attachment.data}
-      <b>PDF present:</b> <a href={"data:application/pdf;base64," + content.attachment.data} target="_blank" rel="noopener noreferrer">View</a>
+    {#if content.attachment && content.attachment.contentType === "application/pdf" && content.attachment.data}
+      {#await base64toBlob(content.attachment.data, content.attachment.contentType) then url}
+        <b>PDF present:</b> <a href={url} target="_blank" rel="noopener noreferrer">View</a>
+      {/await}
     {/if}
   {/each}
 {/if}

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -7,3 +7,8 @@ export function randomStringWithEntropy(entropy = 32): string {
   crypto.getRandomValues(b);
   return base64url.encode(b);
 }
+
+export async function base64toBlob(base64:string, type="application/octet-stream") {
+  let result = await fetch(`data:${type};base64,${base64}`);
+  return window.URL.createObjectURL(await result.blob());
+}


### PR DESCRIPTION
Converts base64 data in advance directive resources to blobs to better support links in resource preview templates.