### PR TITLE
AdvancedDirective changes during July '24 connectathon

### DIFF
--- a/src/lib/FetchAD.svelte
+++ b/src/lib/FetchAD.svelte
@@ -308,10 +308,24 @@
       // Filter out signature resources
       resources = resources.filter(nonSupersededDR);
 
-      // TODO iterate over DR's that are for signatures.
+      // Iterate over DR's that are for signatures.
       // Get the date from when it was signed, and show that in the card for the DocumentReference
       // that it applies to.
       // That date will be in content.attachment.creation (Lisa to add the evening of 2024-07-17).
+      resources.forEach(dr => {
+        if (dr.relatesTo && dr.relatesTo[0] && dr.relatesTo[0].code && dr.relatesTo[0].code == 'signs'
+          && dr.relatesTo[0].target && dr.relatesTo[0].target.reference) {
+          // e.g. "DocumentReference/9fad9465-5c95-49cf-a8ff-c3b8d782894d"
+          let target = dr.relatesTo[0].target.reference;
+          target = target.substring(18);
+          let pdfSignDate = '(missing from content.attachment.creation in signature DocumentReference)'; // placeholder until Lisa's change
+          if (dr.content && dr.content.attachment && dr.content.attachment){
+            pdfSignDate = dr.content.attachment;
+          }
+          let resourceSigned = resources.find((item) => item.id == target);
+          resourceSigned.pdfSignedDate = pdfSignDate;
+        }
+      });
 
       // July '24: unlike the May '24 connectathon, signature DR's now have resource.category defined.
       // The ADI team is planning to add a code for these later, but for the time being they suggest

--- a/src/lib/FetchAD.svelte
+++ b/src/lib/FetchAD.svelte
@@ -300,10 +300,25 @@
         console.warn("No advance directives found for patient "+patient.id);
       }
 
-      // If resource.category doesn't exist, ignore the DR - DR's w/out that are simply signature DR's.
-      // Lambda function to check if resource.category exists
-      const nonSignatureDR = dr => dr.category !== undefined;
-      // Filter out resources that don't have a category
+      // Filter out DR's with 'status' == 'superseded'. In May '24 we included these,
+      // but they are just noise since IPS doesn't want to address the complexity of
+      // showing these in the UI behind something like a "history" element.
+      // Lambda function to check this:
+      const nonSupersededDR = dr => dr.status !== 'superseded';
+      // Filter out signature resources
+      resources = resources.filter(nonSupersededDR);
+
+      // TODO iterate over DR's that are for signatures.
+      // Get the date from when it was signed, and show that in the card for the DocumentReference
+      // that it applies to.
+      // That date will be in content.attachment.creation (Lisa to add the evening of 2024-07-17).
+
+      // July '24: unlike the May '24 connectathon, signature DR's now have resource.category defined.
+      // The ADI team is planning to add a code for these later, but for the time being they suggest
+      // that we identify these by: "description": "JWS of the FHIR Document",
+      // FIXME may be better to do this when we iterate for the TODO above.
+      const nonSignatureDR = dr => dr.description !== 'JWS of the FHIR Document';
+      // Filter out signature resources
       resources = resources.filter(nonSignatureDR);
 
       // if one of the DR's `content` elements has attachment.contentType = 'application/pdf', download if possible, put base64 of pdf in DR.content.attachment.data

--- a/src/lib/FetchAD.svelte
+++ b/src/lib/FetchAD.svelte
@@ -323,7 +323,7 @@
             pdfSignDate = dr.content.attachment;
           }
           let resourceSigned = resources.find((item) => item.id == target);
-          resourceSigned.pdfSignedDate = pdfSignDate;
+          resourceSigned.pdfSignedDate = pdfSignDate; // pdfSignedDate is an ad-hoc property name
         }
       });
 

--- a/src/lib/FetchAD.svelte
+++ b/src/lib/FetchAD.svelte
@@ -319,8 +319,8 @@
           let target = dr.relatesTo[0].target.reference;
           target = target.substring(18);
           let pdfSignDate = '(missing from content.attachment.creation in signature DocumentReference)'; // placeholder until Lisa's change
-          if (dr.content && dr.content.attachment && dr.content.attachment){
-            pdfSignDate = dr.content.attachment;
+          if (dr.content && dr.content[0] && dr.content[0].attachment && dr.content[0].attachment.creation){
+            pdfSignDate = dr.content[0].attachment.creation;
           }
           let resourceSigned = resources.find((item) => item.id == target);
           resourceSigned.pdfSignedDate = pdfSignDate; // pdfSignedDate is an ad-hoc property name

--- a/src/lib/resource-templates/AdvanceDirective.svelte
+++ b/src/lib/resource-templates/AdvanceDirective.svelte
@@ -46,9 +46,8 @@ Text:
 <br />
 <b>Version number:</b>
 {#if resource.extension && resource.extension[0] && resource.extension[0].url && resource.extension[0].url == 'http://hl7.org/fhir/us/ccda/StructureDefinition/VersionNumber'}
-<!--  As a generic value (current IG): {resource.extension[0]}
-  As a generic value (current IG): {resource.extension[0].value} -->
-  As an integer (prior IG): {resource.extension[0].valueInteger}
+  <!-- As of the July '24 this is now a unix time stamp --> 
+  {resource.extension[0].valueInteger}
 {/if}
 <br />
 <!-- This is the date that the DocumentReference resource was created, not of interest.

--- a/src/lib/resource-templates/AdvanceDirective.svelte
+++ b/src/lib/resource-templates/AdvanceDirective.svelte
@@ -77,11 +77,11 @@ Text:
       {#await base64toBlob(content.attachment.data, content.attachment.contentType) then url}
         <b>PDF present:</b> <a href={url} target="_blank" rel="noopener noreferrer">View</a>
         {#if content.attachment && content.attachment.creation}
-          Date of PDF creation: {new Date(content.attachment.creation).toISOString().slice(0,10)}.  
+          Date PDF created: {new Date(content.attachment.creation).toISOString().slice(0,10)}.  
         {/if}
         {#if resource.pdfSignedDate}
           <!-- Date PDF was signed: {new Date(content.attachment.creation).toISOString().slice(0,10)}.-->
-          Date PDF was signed: {resource.pdfSignedDate}.
+          Date PDF signed: {new Date(resource.pdfSignedDate).toISOString().slice(0,10)}.
         {/if}
       {/await}
     {/if}

--- a/src/lib/resource-templates/AdvanceDirective.svelte
+++ b/src/lib/resource-templates/AdvanceDirective.svelte
@@ -72,17 +72,20 @@ Text:
 {/if}
 <br/>
 {#if resource.content}
+<!-- FIXME This iteration not ideal - should iterate whether pdf present or not, as created & pdfSignedDate (ill-named) actually refer to the larget context of the DR, not the pdf... as it stands the Personal Advance Care Plan Document won't show created/signed (bug), tho we don't care so much about that one in IPS. 
+-->
   {#each resource.content as content}
     {#if content.attachment && content.attachment.contentType === "application/pdf" && content.attachment.data}
       {#await base64toBlob(content.attachment.data, content.attachment.contentType) then url}
-        <b>PDF present:</b> 
         {#if content.attachment && content.attachment.creation}
-          PDF created: {new Date(content.attachment.creation).toISOString().slice(0,10)}.  
+          <b>Created:</b> {new Date(content.attachment.creation).toISOString().slice(0,10)}
+					<br/>
         {/if}
         {#if resource.pdfSignedDate}
-          <!-- Date PDF was signed: {new Date(content.attachment.creation).toISOString().slice(0,10)}.-->
-          PDF signed: {new Date(resource.pdfSignedDate).toISOString().slice(0,10)}.
+          <b>Digitally signed:</b> {new Date(resource.pdfSignedDate).toISOString().slice(0,10)}
+					<br/>
         {/if}
+        <b>PDF present:</b> 
       <a href={url} target="_blank" rel="noopener noreferrer">View</a>
       {/await}
     {/if}

--- a/src/lib/resource-templates/AdvanceDirective.svelte
+++ b/src/lib/resource-templates/AdvanceDirective.svelte
@@ -75,7 +75,7 @@ Text:
   {#each resource.content as content}
     {#if content.attachment && content.attachment.contentType === "application/pdf" && content.attachment.data}
       {#await base64toBlob(content.attachment.data, content.attachment.contentType) then url}
-        <b>PDF present:</b> <a href={url} target="_blank" rel="noopener noreferrer">View</a>
+        <b>PDF present:</b> 
         {#if content.attachment && content.attachment.creation}
           Date PDF created: {new Date(content.attachment.creation).toISOString().slice(0,10)}.  
         {/if}
@@ -83,6 +83,7 @@ Text:
           <!-- Date PDF was signed: {new Date(content.attachment.creation).toISOString().slice(0,10)}.-->
           Date PDF signed: {new Date(resource.pdfSignedDate).toISOString().slice(0,10)}.
         {/if}
+      <a href={url} target="_blank" rel="noopener noreferrer">View</a>
       {/await}
     {/if}
   {/each}

--- a/src/lib/resource-templates/AdvanceDirective.svelte
+++ b/src/lib/resource-templates/AdvanceDirective.svelte
@@ -77,11 +77,11 @@ Text:
       {#await base64toBlob(content.attachment.data, content.attachment.contentType) then url}
         <b>PDF present:</b> 
         {#if content.attachment && content.attachment.creation}
-          Date PDF created: {new Date(content.attachment.creation).toISOString().slice(0,10)}.  
+          PDF created: {new Date(content.attachment.creation).toISOString().slice(0,10)}.  
         {/if}
         {#if resource.pdfSignedDate}
           <!-- Date PDF was signed: {new Date(content.attachment.creation).toISOString().slice(0,10)}.-->
-          Date PDF signed: {new Date(resource.pdfSignedDate).toISOString().slice(0,10)}.
+          PDF signed: {new Date(resource.pdfSignedDate).toISOString().slice(0,10)}.
         {/if}
       <a href={url} target="_blank" rel="noopener noreferrer">View</a>
       {/await}

--- a/src/lib/resource-templates/AdvanceDirective.svelte
+++ b/src/lib/resource-templates/AdvanceDirective.svelte
@@ -46,14 +46,18 @@ Text:
 <br />
 <b>Version number:</b>
 {#if resource.extension && resource.extension[0] && resource.extension[0].url && resource.extension[0].url == 'http://hl7.org/fhir/us/ccda/StructureDefinition/VersionNumber'}
-  {resource.extension[0].valueInteger}
+<!--  As a generic value (current IG): {resource.extension[0]}
+  As a generic value (current IG): {resource.extension[0].value} -->
+  As an integer (prior IG): {resource.extension[0].valueInteger}
 {/if}
 <br />
+<!-- This is the date that the DocumentReference resource was created, not of interest.
 <b>Date:</b>
 {#if resource.date}
   {resource.date}
 {/if}
 <br />
+-->
 <b>Status:</b>
 {#if resource.status}
   {resource.status}
@@ -73,6 +77,9 @@ Text:
     {#if content.attachment && content.attachment.contentType === "application/pdf" && content.attachment.data}
       {#await base64toBlob(content.attachment.data, content.attachment.contentType) then url}
         <b>PDF present:</b> <a href={url} target="_blank" rel="noopener noreferrer">View</a>
+        {#if content.attachment && content.attachment.creation}
+          Date of PDF creation: {new Date(content.attachment.creation).toISOString().slice(0,10)}.  
+        {/if}
       {/await}
     {/if}
   {/each}

--- a/src/lib/resource-templates/AdvanceDirective.svelte
+++ b/src/lib/resource-templates/AdvanceDirective.svelte
@@ -79,6 +79,10 @@ Text:
         {#if content.attachment && content.attachment.creation}
           Date of PDF creation: {new Date(content.attachment.creation).toISOString().slice(0,10)}.  
         {/if}
+        {#if resource.pdfSignedDate}
+          <!-- Date PDF was signed: {new Date(content.attachment.creation).toISOString().slice(0,10)}.-->
+          Date PDF was signed: {resource.pdfSignedDate}.
+        {/if}
       {/await}
     {/if}
   {/each}


### PR DESCRIPTION
1. Show date of PDF creation.
2. Hide DocumentReference.date.
3. Update the "nonSignatureDR" filter to accommodate changes in reference implementation. 
4. DocumentReference resources for signatures: find their target.reference (itelf a DR) and write the signature's signing date to the target DR.