### PR TITLE
AD: Sept Connectathon final state (as recorded for report-out)

### DIFF
--- a/src/lib/FetchAD.svelte
+++ b/src/lib/FetchAD.svelte
@@ -381,27 +381,16 @@
             // look in that content's attachment.url, that will point at a Bundle (e.g. https://qa-rr-fhir2.maxmddirect.com/Bundle/10f4ff31-2c24-414d-8d70-de3a86bed808?_format=json)
             const adipmoBundleUrl = contentAdipmoBundleRef.attachment.url;
             // Pull that Bundle.
-            //let adipmoBundle;
-            /**adipmoBundle = await Promise.all([
-              fetchResourceByUrl(adipmoBundleUrl)
-            ]);*/
             let adipmoBundle = await fetchResourceByUrl(adipmoBundleUrl);
-            //if (adipmoBundle.json() != undefined){
             let adipmoBundleJson = await adipmoBundle.json();
-            //adipmoBundleJson = adipmoBundle.json();
-            //adipmoBundleJson = adipmoBundle;
-            //   That bundle will include ServiceRequest resources.
+            //   That bundle will include ServiceRequest resources; look for the one for CPR (loinc 100822-6) 
             const serviceRequest = adipmoBundleJson.entry.find(
               entry => entry.resource && entry.resource.resourceType === 'ServiceRequest'
               && entry.resource.category && entry.resource.category[0].coding[0].code === '100822-6');
-            //serviceRequests.forEach( serviceRequest => {
-              //const serviceRequestCpr = serviceRequests.find(serviceRequests => serviceRequests.category.coding.code "100822-6" (system http://loinc.org) - that's the one for CPR.
-              //const isCpr = serviceRequest.category[0].coding[0].code === '100822-6';
-            const doNotPerform = serviceRequest.resource.doNotPerform && serviceRequest.resource.doNotPerform == true;
-            //dr.isCpr = isCpr;
-            dr.doNotPerform = doNotPerform;
-            //});
-          //}
+            dr.isCpr = false;
+            if (serviceRequest !== undefined) dr.isCpr = true;
+
+            dr.doNotPerform = serviceRequest.resource.doNotPerform && serviceRequest.resource.doNotPerform == true;
           }
         }
       });

--- a/src/lib/FetchAD.svelte
+++ b/src/lib/FetchAD.svelte
@@ -368,31 +368,27 @@
       // if one of the DR's `content` elements has attachment.contentType = 'application/pdf', download if possible, put base64 of pdf in DR.content.attachment.data
       const hasPdfContent = dr => dr.content && dr.content.some(content => content.attachment && content.attachment.contentType === 'application/pdf' && !content.attachment.data);
 
-      // if one of the DR's 
+      // if one of the DR's
       const isPolst = dr => dr.type && dr.type.coding && dr.type.coding.some(coding => coding.system === 'http://loinc.org' && coding.code === '100821-8');
 
-      resources.forEach(async dr => {
-        if (hasPdfContent(dr)) {
-          const pdfContent = dr.content.find(content => content.attachment && content.attachment.contentType === 'application/pdf');
-          if (pdfContent && pdfContent.attachment && pdfContent.attachment.url) {
-            await injectPdfIntoDocRef (pdfContent.attachment.url, pdfContent.attachment);
-          }
-        }
-      });
       resources.forEach(async dr => {
         // If this DR is a POLST, add the following chain of queries:
         if (isPolst(dr)){
           // In the POLST find the content[] with format.code = "urn:hl7-org:pe:adipmo-structuredBody:1.1" (ADIPMO Structured Body Bundle),
-          const contentAdipmoBundleRef = dr.content.find(content => content.format && content.format.code && content.format.code === 'urn:hl7-org:pe:adipmo-structuredBody:1.1');
+          const contentAdipmoBundleRef = dr.content.find(content => content.format && content.format.code && content.format.code === 'urn:hl7-org:pe:adipmo-structuredBody:1.1' && content.attachment && content.attachment.url && content.attachment.url.includes('Bundle'));
           if (contentAdipmoBundleRef) {
             // look in that content's attachment.url, that will point at a Bundle (e.g. https://qa-rr-fhir2.maxmddirect.com/Bundle/10f4ff31-2c24-414d-8d70-de3a86bed808?_format=json)
             const adipmoBundleUrl = contentAdipmoBundleRef.attachment.url;
             // Pull that Bundle.
-            let adipmoBundle;
-            adipmoBundle = await fetchResourceByUrl(adipmoBundleUrl);
-            let adipmoBundleJson;
-            //adipmoBundleJson = await adipmoBundle.json();
-            adipmoBundleJson = adipmoBundle.json();
+            //let adipmoBundle;
+            /**adipmoBundle = await Promise.all([
+              fetchResourceByUrl(adipmoBundleUrl)
+            ]);*/
+            let adipmoBundle = await fetchResourceByUrl(adipmoBundleUrl);
+            //if (adipmoBundle.json() != undefined){
+            let adipmoBundleJson = await adipmoBundle.json();
+            //adipmoBundleJson = adipmoBundle.json();
+            //adipmoBundleJson = adipmoBundle;
             //   That bundle will include ServiceRequest resources.
             const serviceRequest = adipmoBundleJson.entry.find(entry => entry.resource && entry.resource.resourceType === 'ServiceRequest' && entry.category[0].coding[0].code === '100822-6');
             //serviceRequests.forEach( serviceRequest => {
@@ -402,6 +398,15 @@
             dr.isCpr = isCpr;
             dr.doNotPerform = doNotPerform;
             //});
+          //}
+          }
+        }
+      });
+      resources.forEach(async dr => {
+        if (hasPdfContent(dr)) {
+          const pdfContent = dr.content.find(content => content.attachment && content.attachment.contentType === 'application/pdf');
+          if (pdfContent && pdfContent.attachment && pdfContent.attachment.url) {
+            await injectPdfIntoDocRef (pdfContent.attachment.url, pdfContent.attachment);
           }
         }
       });

--- a/src/lib/FetchAD.svelte
+++ b/src/lib/FetchAD.svelte
@@ -374,6 +374,7 @@
       resources.forEach(async dr => {
         // If this DR is a POLST, add the following chain of queries:
         if (isPolst(dr)){
+          dr.isPolst = true;
           // In the POLST find the content[] with format.code = "urn:hl7-org:pe:adipmo-structuredBody:1.1" (ADIPMO Structured Body Bundle),
           const contentAdipmoBundleRef = dr.content.find(content => content.format && content.format.code && content.format.code === 'urn:hl7-org:pe:adipmo-structuredBody:1.1' && content.attachment && content.attachment.url && content.attachment.url.includes('Bundle'));
           if (contentAdipmoBundleRef) {
@@ -390,12 +391,14 @@
             //adipmoBundleJson = adipmoBundle.json();
             //adipmoBundleJson = adipmoBundle;
             //   That bundle will include ServiceRequest resources.
-            const serviceRequest = adipmoBundleJson.entry.find(entry => entry.resource && entry.resource.resourceType === 'ServiceRequest' && entry.category[0].coding[0].code === '100822-6');
+            const serviceRequest = adipmoBundleJson.entry.find(
+              entry => entry.resource && entry.resource.resourceType === 'ServiceRequest'
+              && entry.resource.category && entry.resource.category[0].coding[0].code === '100822-6');
             //serviceRequests.forEach( serviceRequest => {
               //const serviceRequestCpr = serviceRequests.find(serviceRequests => serviceRequests.category.coding.code "100822-6" (system http://loinc.org) - that's the one for CPR.
               //const isCpr = serviceRequest.category[0].coding[0].code === '100822-6';
-            const doNotPerform = serviceRequest.doNotPerform && serviceRequest.doNotPerform == true;
-            dr.isCpr = isCpr;
+            const doNotPerform = serviceRequest.resource.doNotPerform && serviceRequest.resource.doNotPerform == true;
+            //dr.isCpr = isCpr;
             dr.doNotPerform = doNotPerform;
             //});
           //}

--- a/src/lib/FetchAD.svelte
+++ b/src/lib/FetchAD.svelte
@@ -383,14 +383,46 @@
             // Pull that Bundle.
             let adipmoBundle = await fetchResourceByUrl(adipmoBundleUrl);
             let adipmoBundleJson = await adipmoBundle.json();
-            //   That bundle will include ServiceRequest resources; look for the one for CPR (loinc 100822-6) 
-            const serviceRequest = adipmoBundleJson.entry.find(
+
+            // TODO The next 4 sections should be generalized into an iteration, just need carve out for "detail" for 2.
+
+            // That bundle will include ServiceRequest resources; look for the one for CPR (loinc 100822-6) 
+            const serviceRequestCpr = adipmoBundleJson.entry.find(
               entry => entry.resource && entry.resource.resourceType === 'ServiceRequest'
               && entry.resource.category && entry.resource.category[0].coding[0].code === '100822-6');
             dr.isCpr = false;
-            if (serviceRequest !== undefined) dr.isCpr = true;
+            if (serviceRequestCpr !== undefined) dr.isCpr = true;
+            dr.doNotPerformCpr = serviceRequestCpr.resource.doNotPerform && serviceRequestCpr.resource.doNotPerform == true;
 
-            dr.doNotPerform = serviceRequest.resource.doNotPerform && serviceRequest.resource.doNotPerform == true;
+            // That bundle will include ServiceRequest resources; look for the one for "Initial portable medical treatment orders" (loinc 100823-4) aka Comfort Treatments
+            const serviceRequestComfortTreatments = adipmoBundleJson.entry.find(
+              entry => entry.resource && entry.resource.resourceType === 'ServiceRequest'
+              && entry.resource.category && entry.resource.category[0].coding[0].code === '100823-4');
+            dr.isComfortTreatments = false;
+            if (serviceRequestComfortTreatments !== undefined) dr.isComfortTreatments = true;
+            dr.doNotPerformComfortTreatments = serviceRequestComfortTreatments.resource.doNotPerform && serviceRequestComfortTreatments.resource.doNotPerform == true;
+
+            dr.detailComfortTreatments = serviceRequestComfortTreatments.resource.note[0].text;
+
+            // That bundle will include ServiceRequest resources; look for the one for "Additional..." (loinc 100824-2)
+            const serviceRequestAdditionalTx = adipmoBundleJson.entry.find(
+              entry => entry.resource && entry.resource.resourceType === 'ServiceRequest'
+              && entry.resource.category && entry.resource.category[0].coding[0].code === '100824-2');
+            dr.isAdditionalTx = false;
+            if (serviceRequestAdditionalTx !== undefined) dr.isAdditionalTx = true;
+            dr.doNotPerformAdditionalTx = serviceRequestAdditionalTx.resource.doNotPerform && serviceRequestAdditionalTx.resource.doNotPerform == true;
+
+            dr.detailAdditionalTx = serviceRequestAdditionalTx.resource.orderDetail[0].text;
+
+            // That bundle will include ServiceRequest resources; look for the one for "Medically assisted nutrition orders" (loinc 100825-9)
+            const serviceRequestMedicallyAssisted = adipmoBundleJson.entry.find(
+              entry => entry.resource && entry.resource.resourceType === 'ServiceRequest'
+              && entry.resource.category && entry.resource.category[0].coding[0].code === '100825-9');
+            dr.isMedicallyAssisted = false;
+            if (serviceRequestMedicallyAssisted !== undefined) dr.isMedicallyAssisted = true;
+            dr.doNotPerformMedicallyAssisted = serviceRequestMedicallyAssisted.resource.doNotPerform && serviceRequestMedicallyAssisted.resource.doNotPerform == true;
+
+            dr.detailMedicallyAssisted = serviceRequestMedicallyAssisted.resource.orderDetail[0].text;
           }
         }
       });

--- a/src/lib/resource-templates/AdvanceDirective.svelte
+++ b/src/lib/resource-templates/AdvanceDirective.svelte
@@ -62,6 +62,17 @@ Text:
   {resource.status}
 {/if}
 <br />
+
+<!-- Revoke Status -->
+{#if resource.extension}
+  {#each resource.extension as ext}
+    {#if ext.url == 'http://hl7.org/fhir/us/pacio-adi/StructureDefinition/adi-document-revoke-status-extension'}
+      <b>Revoke Status:</b> {ext.valueCoding.code}
+      <br />
+    {/if}
+  {/each}
+{/if}
+
 <b>docStatus:</b>
 {#if resource.docStatus}
   {resource.docStatus}

--- a/src/lib/resource-templates/AdvanceDirective.svelte
+++ b/src/lib/resource-templates/AdvanceDirective.svelte
@@ -84,15 +84,57 @@ Text:
 <br/>
 
 {#if resource.isPolst}
-{#if resource.isCpr}
-{#if resource.doNotPerform}
-  <b>This includes a directive to NOT perform CPR.</b>
+<br/>
+  <b>
+  POLST Details:
+<br/>
+    <ul>
+      {#if resource.isCpr}
+        <ol>
+{#if resource.doNotPerformCpr}
+  This includes a directive to NOT perform CPR.
 {:else}
-  <b>This includes a directive to perform CPR.</b>
+  This includes a directive to perform CPR.
 {/if}
-{/if}
+        </ol>
 {/if}
 <br/>
+
+{#if resource.isComfortTreatments}
+        <ol>
+{#if resource.doNotPerformComfortTreatments}
+  This includes a directive to NOT perform comfort-focused treatments: {@html resource.detailComfortTreatments}
+{:else}
+  This includes a directive to perform comfort-focused treatments: {@html resource.detailComfortTreatments}
+{/if}
+        </ol>
+{/if}
+<br/>
+
+{#if resource.isAdditionalTx}
+        <ol>
+{#if resource.doNotPerformAdditionalTx}
+  This includes a directive to NOT perform additional treatments: {@html resource.detailAdditionalTx}
+{:else}
+  This includes a directive to perform additional treatments: {@html resource.detailAdditionalTx}
+{/if}
+        </ol>
+{/if}
+<br/>
+
+{#if resource.isMedicallyAssisted}
+        <ol>
+{#if resource.doNotPerformMedicallyAssisted}
+  This includes a directive to NOT perform medically assisted nutrition: {@html resource.detailMedicallyAssisted}
+{:else}
+  This includes a directive to perform medically assisted nutrition: {@html resource.detailMedicallyAssisted}
+{/if}
+        </ol>
+{/if}
+</ul>
+</b>
+<br/>
+{/if}
 
 {#if resource.content}
 <!-- FIXME This iteration not ideal - should iterate whether pdf present or not, as created & pdfSignedDate (ill-named) actually refer to the larget context of the DR, not the pdf... as it stands the Personal Advance Care Plan Document won't show created/signed (bug), tho we don't care so much about that one in IPS. 

--- a/src/lib/resource-templates/AdvanceDirective.svelte
+++ b/src/lib/resource-templates/AdvanceDirective.svelte
@@ -21,13 +21,9 @@
     );
   }
 
-
 </script>
 
-{#if isRevoked}
-  <div class="less-interest">
-</div>
-{/if}
+<div class:is-revoked={isRevoked}>
 
 <!--
 Type: {resource.resourceType}
@@ -186,12 +182,10 @@ Text:
   {/each}
 {/if}
 
-{#if isRevoked}
- <!-- </div> -->
-{/if}
+</div>
 
 <style>
-  .less-interest {
+  .is-revoked {
     background-color: #f0f0f0; /* Light gray background */
     padding: 10px;
     border-radius: 5px;

--- a/src/lib/resource-templates/AdvanceDirective.svelte
+++ b/src/lib/resource-templates/AdvanceDirective.svelte
@@ -84,10 +84,12 @@ Text:
 <br/>
 
 {#if resource.isPolst}
-<b>This is a POLST.</b>
-  <br />
+{#if resource.isCpr}
 {#if resource.doNotPerform}
-  doNotPerform = true.
+  <b>This includes a directive to NOT perform CPR.</b>
+{:else}
+  <b>This includes a directive to perform CPR.</b>
+{/if}
 {/if}
 {/if}
 <br/>

--- a/src/lib/resource-templates/AdvanceDirective.svelte
+++ b/src/lib/resource-templates/AdvanceDirective.svelte
@@ -185,9 +185,22 @@ Text:
 </div>
 
 <style>
+  .is-revoked1 {
+    background-color: #f0f0f0; /* Light gray background */
+    padding: 10px;
+    border-radius: 5px;
+  }
   .is-revoked {
     background-color: #f0f0f0; /* Light gray background */
     padding: 10px;
     border-radius: 5px;
+    background-image: 
+      linear-gradient(135deg, rgba(255,255,255,0.3) 25%, transparent 25%),
+      linear-gradient(225deg, rgba(255,255,255,0.3) 25%, transparent 25%),
+      linear-gradient(45deg, rgba(255,255,255,0.3) 25%, transparent 25%),
+      linear-gradient(315deg, rgba(255,255,255,0.3) 25%, transparent 25%);
+    background-size: 40px 40px; /* Adjusts the size of the pattern */
+    background-position: 10px 10px; /* Adjusts the offset of the pattern */
+    opacity: 0.95; /* Slight transparency for a more subtle effect */
   }
 </style>

--- a/src/lib/resource-templates/AdvanceDirective.svelte
+++ b/src/lib/resource-templates/AdvanceDirective.svelte
@@ -2,17 +2,31 @@
   import { base64toBlob } from '$lib/util';
   export let resource; // Define a prop to pass the data to the component
 
-  // Determine if any extension has the revoked status
+  /** Determine if any extension has the revoked status
   let isRevoked = false;
   if (resource.extension) {
     isRevoked = resource.extension.some(
       ext => ext.url === 'http://hl7.org/fhir/us/pacio-adi/StructureDefinition/adi-document-revoke-status-extension' && ext.valueCoding.code === 'cancelled'
     );
   }
+*/
+
+  // Determine if any extension has the revoked status reactively
+  let isRevoked = false;
+
+  // Reactive declaration to update isRevoked when resource.extension changes
+  $: if (resource.extension) {
+    isRevoked = resource.extension.some(
+      ext => ext.url === 'http://hl7.org/fhir/us/pacio-adi/StructureDefinition/adi-document-revoke-status-extension' && ext.valueCoding.code === 'cancelled'
+    );
+  }
+
+
 </script>
 
 {#if isRevoked}
   <div class="less-interest">
+</div>
 {/if}
 
 <!--
@@ -173,7 +187,7 @@ Text:
 {/if}
 
 {#if isRevoked}
-  </div>
+ <!-- </div> -->
 {/if}
 
 <style>

--- a/src/lib/resource-templates/AdvanceDirective.svelte
+++ b/src/lib/resource-templates/AdvanceDirective.svelte
@@ -115,9 +115,9 @@ Text:
       {#if resource.isCpr}
         <ol>
 {#if resource.doNotPerformCpr}
-  This includes a directive to NOT perform CPR.
+  This includes an order to NOT perform CPR.
 {:else}
-  This includes a directive to perform CPR.
+  This includes an order to perform CPR.
 {/if}
         </ol>
 {/if}
@@ -126,9 +126,9 @@ Text:
 {#if resource.isComfortTreatments}
         <ol>
 {#if resource.doNotPerformComfortTreatments}
-  This includes a directive to NOT perform comfort-focused treatments: {@html resource.detailComfortTreatments}
+  This includes an order to NOT perform comfort-focused treatments: {@html resource.detailComfortTreatments}
 {:else}
-  This includes a directive to perform comfort-focused treatments: {@html resource.detailComfortTreatments}
+  This includes an order to perform comfort-focused treatments: {@html resource.detailComfortTreatments}
 {/if}
         </ol>
 {/if}
@@ -137,9 +137,9 @@ Text:
 {#if resource.isAdditionalTx}
         <ol>
 {#if resource.doNotPerformAdditionalTx}
-  This includes a directive to NOT perform additional treatments: {@html resource.detailAdditionalTx}
+  This includes an order to NOT perform additional treatments: {@html resource.detailAdditionalTx}
 {:else}
-  This includes a directive to perform additional treatments: {@html resource.detailAdditionalTx}
+  This includes an order to perform additional treatments: {@html resource.detailAdditionalTx}
 {/if}
         </ol>
 {/if}
@@ -148,9 +148,9 @@ Text:
 {#if resource.isMedicallyAssisted}
         <ol>
 {#if resource.doNotPerformMedicallyAssisted}
-  This includes a directive to NOT perform medically assisted nutrition: {@html resource.detailMedicallyAssisted}
+  This includes an order to NOT perform medically assisted nutrition: {@html resource.detailMedicallyAssisted}
 {:else}
-  This includes a directive to perform medically assisted nutrition: {@html resource.detailMedicallyAssisted}
+  This includes an order to perform medically assisted nutrition: {@html resource.detailMedicallyAssisted}
 {/if}
         </ol>
 {/if}

--- a/src/lib/resource-templates/AdvanceDirective.svelte
+++ b/src/lib/resource-templates/AdvanceDirective.svelte
@@ -88,6 +88,7 @@ Text:
   <b>
   POLST Details:
 <br/>
+<br/>
     <ul>
       {#if resource.isCpr}
         <ol>
@@ -147,8 +148,10 @@ Text:
 					<br/>
         {/if}
         {#if resource.pdfSignedDate}
+          <!--
           <b>Digitally signed:</b> {new Date(resource.pdfSignedDate).toISOString().slice(0,10)}
-					<br/>
+          <br/>
+          -->
         {/if}
         <b>PDF present:</b> 
       <a href={url} target="_blank" rel="noopener noreferrer">View</a>

--- a/src/lib/resource-templates/AdvanceDirective.svelte
+++ b/src/lib/resource-templates/AdvanceDirective.svelte
@@ -1,7 +1,19 @@
 <script>
   import { base64toBlob } from '$lib/util';
   export let resource; // Define a prop to pass the data to the component
+
+  // Determine if any extension has the revoked status
+  let isRevoked = false;
+  if (resource.extension) {
+    isRevoked = resource.extension.some(
+      ext => ext.url === 'http://hl7.org/fhir/us/pacio-adi/StructureDefinition/adi-document-revoke-status-extension' && ext.valueCoding.code === 'cancelled'
+    );
+  }
 </script>
+
+{#if isRevoked}
+  <div class="less-interest">
+{/if}
 
 <!--
 Type: {resource.resourceType}
@@ -159,3 +171,15 @@ Text:
     {/if}
   {/each}
 {/if}
+
+{#if isRevoked}
+  </div>
+{/if}
+
+<style>
+  .less-interest {
+    background-color: #f0f0f0; /* Light gray background */
+    padding: 10px;
+    border-radius: 5px;
+  }
+</style>

--- a/src/lib/resource-templates/AdvanceDirective.svelte
+++ b/src/lib/resource-templates/AdvanceDirective.svelte
@@ -82,6 +82,16 @@ Text:
   {resource.description.text}
 {/if}
 <br/>
+
+{#if resource.isPolst}
+<b>This is a POLST.</b>
+  <br />
+{#if resource.doNotPerform}
+  doNotPerform = true.
+{/if}
+{/if}
+<br/>
+
 {#if resource.content}
 <!-- FIXME This iteration not ideal - should iterate whether pdf present or not, as created & pdfSignedDate (ill-named) actually refer to the larget context of the DR, not the pdf... as it stands the Personal Advance Care Plan Document won't show created/signed (bug), tho we don't care so much about that one in IPS. 
 -->


### PR DESCRIPTION
This implements:
- structured data in the POLST (4 elements)
- watermark on revoked AD's.
- Removed per Lisa's suggestion: "Digitally signed" datetime (was just a datetime from today - ADVault processing)

Also addresses this: https://github.com/uwcirg/shl-ips/issues/30

TODO's post-cthon
Add "Signed by (the "legal authenticator"), on (date)" - this date is in the same block as the as the legal authenticator person.
Make watermark for revoked a bit more obvious.