### PR TITLE
01 25 cat viewer

### DIFF
--- a/src/lib/components/app/ResourceSelector.svelte
+++ b/src/lib/components/app/ResourceSelector.svelte
@@ -281,9 +281,10 @@
                                                     <Button
                                                         size="sm"
                                                         color="secondary"
+                                                        outline
                                                         on:click={() => setJson($resourcesByTypeStore[resourceType][key])}
                                                     >
-                                                        JSON
+                                                        View
                                                     </Button>
                                                 </Col>
                                             {/if}
@@ -292,7 +293,7 @@
                                     <Label style="width: 100%">
                                         <CardBody>
                                             <Row style="overflow:hidden">
-                                                <Col xs=auto class="d-flex align-items-center pe-0">
+                                                <Col xs=auto class="d-flex align-items-top pt-4 pe-0">
                                                     {#if resourceType === "Patient"}
                                                         <Input id={key} type="radio" bind:group={selectedPatient} value={key} />
                                                     {:else}
@@ -301,7 +302,11 @@
                                                 </Col>
                                                 <Col>
                                                     {#if resourceType in components}
-                                                        <svelte:component this={components[resourceType]} resource={$resourcesByTypeStore[resourceType][key].resource} />
+                                                        <svelte:component
+                                                            this={components[resourceType]}
+                                                            content={{
+                                                                resource: $resourcesByTypeStore[resourceType][key].resource,
+                                                                entries: resourceCollection.flattenResources($resourcesByTypeStore)}} />
                                                         <!-- ResourceType: {resourceType}
                                                         Resource: {JSON.stringify($resourcesByTypeStore[resourceType][key].resource)} -->
                                                     {:else if $resourcesByTypeStore[resourceType][key].resource.text?.div}
@@ -325,6 +330,49 @@
 </AccordionItem>
 
 <style>
+    /* Table styling */
+  :global(table) {
+    border-collapse: collapse !important;
+    width: 100% !important;
+  }
+
+  :global(th) {
+    border: 1px solid lightgray !important;
+    padding: 0 7px !important;
+    text-align: center !important;
+  }
+
+  :global(td) {
+    margin-left: 2em !important;
+  }
+
+  :global(thead) {
+    background-color: #0c63e4;
+    color: white;
+  }
+
+  /* Alternating table row coloring */
+  :global(tbody tr:nth-child(odd)) {
+    background-color: #fff;
+    border: 1px solid lightgray;
+  }
+  :global(tbody tr:nth-child(even)) {
+    background-color: #e7f1ff;
+    border: 1px solid lightgray;
+  }
+  
+  /* Sticky table header */
+  :global(th) {
+    background: #0c63e4;
+    position: sticky;
+    top: -17px;
+  }
+
+  /* First column of generated table is usually most important */
+  :global(td:first-child) {
+    font-weight: bold;
+  }
+
     .code {
         overflow:auto;
         margin: 0;

--- a/src/lib/components/app/ResourceSelector.svelte
+++ b/src/lib/components/app/ResourceSelector.svelte
@@ -300,7 +300,7 @@
                                                         <Input id={key} type="checkbox" bind:checked={$resourcesByTypeStore[resourceType][key].include} value={key} />
                                                     {/if}
                                                 </Col>
-                                                <Col>
+                                                <Col class="justify-content-center align-items-center">
                                                     {#if resourceType in components}
                                                         <svelte:component
                                                             this={components[resourceType]}

--- a/src/lib/components/resource-templates/AdvanceDirective.svelte
+++ b/src/lib/components/resource-templates/AdvanceDirective.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
   import { base64toBlob } from '$lib/utils/util';
-  import type { DocumentReferencePOLST } from '$lib/utils/types';
+  import type { DocumentReferencePOLST, ResourceTemplateParams } from '$lib/utils/types';
+  
+  export let content: ResourceTemplateParams<DocumentReferencePOLST>; // Define a prop to pass the data to the component
 
-  export let resource: DocumentReferencePOLST; // Define a prop to pass the data to the component
+  let resource: DocumentReferencePOLST = content.resource;
 
   /** Determine if any extension has the revoked status
   let isRevoked = false;

--- a/src/lib/components/resource-templates/AllergyIntolerance.svelte
+++ b/src/lib/components/resource-templates/AllergyIntolerance.svelte
@@ -1,8 +1,11 @@
 <script lang="ts">
   import { Badge } from 'sveltestrap';
   import type { AllergyIntolerance } from 'fhir/r4';
+  import type { ResourceTemplateParams } from '$lib/utils/types';
+  
+  export let content: ResourceTemplateParams<AllergyIntolerance>; // Define a prop to pass the data to the component
 
-  export let resource: AllergyIntolerance; // Define a prop to pass the data to the component
+  let resource: AllergyIntolerance = content.resource;
 
   function badgeColor(criticality: string) {
     if (criticality) {

--- a/src/lib/components/resource-templates/Condition.svelte
+++ b/src/lib/components/resource-templates/Condition.svelte
@@ -1,8 +1,11 @@
 <script lang="ts">
   import { Badge } from 'sveltestrap';
   import type { Condition } from 'fhir/r4';
+  import type { ResourceTemplateParams } from '$lib/utils/types';
 
-  export let resource : Condition; // Define a prop to pass the data to the component
+  export let content: ResourceTemplateParams<Condition>; // Define a prop to pass the data to the component
+
+  let resource: Condition = content.resource;
 
   function badgeColor(severity: string) {
     if (severity) {
@@ -57,9 +60,12 @@
     <strong>{resource.code.text}</strong><br>
   {/if}
 {/if}
-{#if resource.bodySite}
-  Site: {resource.bodySite}<br>
+{#if resource.bodySite?.[0]?.coding?.[0]?.display}
+  Site: {resource.bodySite[0]?.coding?.[0]?.display}<br>
 {/if}
 {#if resource.onsetDateTime}
-  Since {resource.onsetDateTime.split("T")[0]}<br>
+  Since: {resource.onsetDateTime.split("T")[0]}<br>
+{/if}
+{#if resource.recordedDate}
+  Recorded: {resource.recordedDate.split("T")[0]}<br>
 {/if}

--- a/src/lib/components/resource-templates/Consent.svelte
+++ b/src/lib/components/resource-templates/Consent.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+  import { Badge } from 'sveltestrap';
+  import type { Consent } from 'fhir/r4';
+  import type { ResourceTemplateParams } from '$lib/utils/types';
+
+  export let content: ResourceTemplateParams<Consent>; // Define a prop to pass the data to the component
+
+  let resource: Consent = content.resource;
+</script>
+{#if resource.text?.div}
+  {@html resource.text.div}
+  <br>
+{/if}
+{#if resource.category?.[0]}
+  {#if resource.category[0].coding}
+    <Badge color="primary">{resource.category[0].coding[0].system} : {resource.category[0].coding[0].code}</Badge>
+    <br />
+    {#if resource.category[0].coding[0].display}
+      <strong>{resource.category[0].coding[0].display}</strong>
+    {:else if resource.category[0].text}
+      <strong>{resource.category[0].text}</strong>
+    {/if}
+    <br>
+  {:else if resource.category[0].text}
+    <strong>{resource.category[0].text}</strong>
+    <br>
+  {/if}
+{/if}
+{#if resource.provision?.code?.[0].coding}
+  Intent: {resource.provision?.code?.[0].coding[0].display}
+{/if}

--- a/src/lib/components/resource-templates/DiagnosticReport.svelte
+++ b/src/lib/components/resource-templates/DiagnosticReport.svelte
@@ -1,42 +1,91 @@
 <script lang="ts">
   import { Badge } from 'sveltestrap';
-  import type { DiagnosticReport } from 'fhir/r4';
+  import type { BundleEntry, DiagnosticReport, Observation } from 'fhir/r4';
+  import ObservationTemplate from './Observation.svelte';
+  import type { ResourceTemplateParams } from '$lib/utils/types';
+  import { getEntry } from '$lib/utils/util';
 
-  export let resource: DiagnosticReport; // Define a prop to pass the data to the component
+  export let content: ResourceTemplateParams<DiagnosticReport>; // Define a prop to pass the data to the component
+
+  let resource: DiagnosticReport = content.resource;
+
+  let results: Observation[] | undefined = [];
+
+  $: {
+    if (resource) {
+      if (resource.result) {
+        for (let result of resource.result) {
+          if (result.reference) {
+            let resultResource;
+            if (resource.contained?.[0]?.resourceType === 'Observation') {
+              // If the result observation is contained in the resource
+              resultResource = resource.contained[0];
+            } else {
+              // If the result observation is referenced
+              resultResource = getEntry(
+                content.entries as BundleEntry[],
+                result.reference
+              ) as Observation;
+            }
+            if (resultResource) {
+              results.push(resultResource);
+            }
+          }
+        }
+      }
+    }
+  }
 </script>
 
+{#if resource.category?.[0].coding}
+  <Badge color="primary">{resource.category[0].coding[0].display ?? resource.category[0].coding[0].code}</Badge>
+{/if}
 {#if resource.code}
   {#if resource.code.coding}
     <Badge color="primary">{resource.code.coding[0].system} : {resource.code.coding[0].code}</Badge>
     <br />
     {#if resource.code.coding[0].display}
-      <strong>{resource.code.coding[0].display}</strong><br>
+      <strong>{resource.code.coding[0].display}</strong>
     {:else if resource.code.text}
-      <strong>{resource.code.text}</strong><br>
+      <strong>{resource.code.text}</strong>
     {/if}
   {:else if resource.code.text}
-    <strong>{resource.code.text}</strong><br>
+    <br><strong>{resource.code.text}</strong>
   {/if}
 {/if}
-{#if resource.effectivePeriod?.start}
-  Effective {resource.effectivePeriod.start}{resource.effectivePeriod.end
+<br>
+{#if resource.effectivePeriod}
+  Effective: {resource.effectivePeriod.start ? resource.effectivePeriod.start : ''}{resource
+    .effectivePeriod.end
     ? ` - ${resource.effectivePeriod.end}`
     : ''}
 {:else if resource.effectiveDateTime}
-    Date: {resource.effectiveDateTime.split("T")[0]}
+  Date: {resource.effectiveDateTime.split('T')[0]}
 {/if}
 <br>
 {#if resource.result}
-    <table class="table table-bordered table-sm">
-        <thead>
-        <tr><th colspan="5">Result(s)</th></tr>
-        </thead>
-        {#each resource.result as result}
-            {#if result.display}
-            <tr>
-                <td>{result.display}</td>
-            </tr>
-            {/if}
-        {/each}
-    </table>
+  <table class="table table-bordered table-sm">
+    <thead>
+      <tr><th>Result(s)</th></tr>
+    </thead>
+    <tbody>
+    {#each results as result}
+      <tr>
+        <div class="ml-4">
+          <ObservationTemplate
+            content={{ resource: result, entries: content.entries }}
+            contained={resource.effectiveDateTime !== undefined || resource.effectivePeriod !== undefined}
+          />
+        </div>
+      </tr>
+    {/each}
+    {#each resource.result as result}
+      {#if result.display}
+        <tr>
+          <td>{result.display}</td>
+        </tr>
+      {/if}
+    {/each}
+    </tbody>
+  </table>
 {/if}

--- a/src/lib/components/resource-templates/Dosage.svelte
+++ b/src/lib/components/resource-templates/Dosage.svelte
@@ -5,6 +5,13 @@
 </script>
 
 {#if dosage}
+  {#if dosage.text}
+    Dosage: {dosage.text}
+  {:else if dosage.asNeededBoolean}
+    Dosage: as needed
+  {:else}
+    <span class="text-muted">No dosage information</span>
+  {/if}
   {#if dosage.route?.coding || dosage.doseAndRate || dosage.timing?.repeat}
     <table class="table table-bordered table-sm">
       <thead>
@@ -17,24 +24,20 @@
           <th scope="col">Freq. Period</th>
         </tr>
       </thead>
-      <tr>
-        <td>{dosage.route?.coding?.[0].display ?? ''}</td>
-        <td>{dosage.doseAndRate?.[0].doseQuantity?.value ?? ''}</td>
-        <td>{dosage.doseAndRate?.[0].doseQuantity?.unit ?? ''}</td>
-        <td>{dosage.timing?.repeat?.count ?? ''}</td>
-        <td>
-          {#if dosage.timing?.repeat?.period && dosage.timing?.repeat?.periodUnit}
-            {dosage.timing?.repeat?.period}{dosage.timing?.repeat?.periodUnit}
-          {/if}
-        </td>
-      </tr>
+      <tbody>
+        <tr>
+          <td>{dosage.route?.coding?.[0].display ?? ''}</td>
+          <td>{dosage.doseAndRate?.[0].doseQuantity?.value ?? ''}</td>
+          <td>{dosage.doseAndRate?.[0].doseQuantity?.unit ?? ''}</td>
+          <td>{dosage.timing?.repeat?.count ?? ''}</td>
+          <td>
+            {#if dosage.timing?.repeat?.period && dosage.timing?.repeat?.periodUnit}
+              {dosage.timing?.repeat?.period}{dosage.timing?.repeat?.periodUnit}
+            {/if}
+          </td>
+        </tr>
+    </tbody>
     </table>
-  {:else if dosage.text}
-    Dosage: {dosage.text}
-  {:else if dosage.asNeededBoolean}
-    Dosage: as needed
-  {:else}
-    <span class="text-muted">No dosage information</span>
   {/if}
 {:else}
   <span class="text-muted">No dosage information</span>

--- a/src/lib/components/resource-templates/Encounter.svelte
+++ b/src/lib/components/resource-templates/Encounter.svelte
@@ -1,8 +1,11 @@
 <script lang="ts">
   import { Badge } from 'sveltestrap';
   import type { Encounter } from 'fhir/r4';
+  import type { ResourceTemplateParams } from '$lib/utils/types';
+  
+  export let content: ResourceTemplateParams<Encounter>; // Define a prop to pass the data to the component
 
-  export let resource: Encounter; // Define a prop to pass the data to the component
+  let resource: Encounter = content.resource;
 </script>
 
 {#if resource.period?.start}

--- a/src/lib/components/resource-templates/Immunization.svelte
+++ b/src/lib/components/resource-templates/Immunization.svelte
@@ -1,8 +1,11 @@
 <script lang="ts">
   import { Badge } from 'sveltestrap';
   import type { Immunization } from 'fhir/r4';
+  import type { ResourceTemplateParams } from '$lib/utils/types';
+  
+  export let content: ResourceTemplateParams<Immunization>; // Define a prop to pass the data to the component
 
-  export let resource: Immunization; // Define a prop to pass the data to the component
+  let resource: Immunization = content.resource;
 </script>
 {#if resource.vaccineCode}
   {#if resource.vaccineCode.coding}

--- a/src/lib/components/resource-templates/Location.svelte
+++ b/src/lib/components/resource-templates/Location.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
   import type { Location } from "fhir/r4";
+  import type { ResourceTemplateParams } from '$lib/utils/types';
   
-  export let resource: Location; // Define a prop to pass the data to the component
+  export let content: ResourceTemplateParams<Location>; // Define a prop to pass the data to the component
+
+  let resource: Location = content.resource;
 </script>
   
 <strong>{resource.name ?? ""}</strong>

--- a/src/lib/components/resource-templates/Medication.svelte
+++ b/src/lib/components/resource-templates/Medication.svelte
@@ -1,22 +1,40 @@
 <script lang="ts">
   import { Badge} from 'sveltestrap';
   import type { Medication } from "fhir/r4";
+  import type { ResourceTemplateParams } from '$lib/utils/types';
 
-  export let resource: Medication; // Define a prop to pass the data to the component
+  export let content: ResourceTemplateParams<Medication>; // Define a prop to pass the data to the component
+
+  let resource: Medication = content.resource;
+  let codingMap = new Map();
 </script>
 
 {#if resource.code}
   {#if resource.code.coding}
     <Badge color="primary">{resource.code.coding[0].system} : {resource.code.coding[0].code}</Badge>
     <br />
-    {#if resource.code.coding[0].display}
-      <strong>{resource.code.coding[0].display}</strong><br>
-    {:else if resource.code.text}
-      <strong>{resource.code.text}</strong><br>
-    {/if}
-  {:else if resource.code.text}
-    <strong>{resource.code.text}</strong><br>
   {/if}
+{/if}
+{#if resource.code?.text}
+  {(codingMap.set(resource.code.text, 1) && undefined) ?? ""}
+  <strong>{resource.code.text}</strong><br>
+{/if}
+{#if resource.code?.coding}
+  {#each resource.code.coding as coding, index}
+    {#if !resource.code?.text && index == 0}
+      <strong>
+        {#if coding.display && !codingMap.get(coding.display)}
+          {(codingMap.set(coding.display, 1) && undefined) ?? ""}
+          {coding.display}<br>
+        {/if}
+      </strong>
+    {:else}
+      {#if coding.display && !codingMap.get(coding.display)}
+        {(codingMap.set(coding.display, 1) && undefined) ?? ""}
+        {coding.display}<br>
+      {/if}
+    {/if}
+  {/each}
 {/if}
 {#if resource.ingredient}
   <table class="table table-bordered table-sm">
@@ -30,8 +48,9 @@
         <th scope="col">Strength Denominator Unit</th>
       </tr>
     </thead>
+    <tbody>
     {#each resource.ingredient as ingredient}
-      <tr>
+      <tr style="text-align: center !important">
         <td>{ingredient.itemCodeableConcept?.coding?.[0].display}</td>
         <td>{ingredient.strength?.numerator?.value}</td>
         <td>{ingredient.strength?.numerator?.unit}</td>
@@ -39,5 +58,6 @@
         <td>{ingredient.strength?.denominator?.unit}</td>
       </tr>
     {/each}
+    </tbody>
   </table>
 {/if}

--- a/src/lib/components/resource-templates/MedicationRequest.svelte
+++ b/src/lib/components/resource-templates/MedicationRequest.svelte
@@ -1,34 +1,72 @@
 <script lang="ts">
   import { Badge } from 'sveltestrap';
-  import type { MedicationRequest } from "fhir/r4";
+  import type { BundleEntry, Medication, MedicationRequest, Resource } from 'fhir/r4';
+  import type { ResourceTemplateParams } from '$lib/utils/types';
   import Dosage from '$lib/components/resource-templates/Dosage.svelte';
-  
-  export let resource: MedicationRequest; // Define a prop to pass the data to the component
+  import MedicationTemplate from '$lib/components/resource-templates/Medication.svelte';
+  import { getEntry } from '$lib/utils/util';
+
+  export let content: ResourceTemplateParams<MedicationRequest>; // Define a prop to pass the data to the component
+
+  let resource: MedicationRequest = content.resource;
+
+  let medication: Medication | undefined;
+
+  $: {
+    if (resource) {
+      if (resource.medicationReference) {
+        if (resource.contained?.[0]?.resourceType === 'Medication') {
+          // If the medication is contained in the resource
+          medication = resource.contained[0];
+        } else if (resource.medicationReference?.reference) {
+          // If the medication is referenced
+          medication = getEntry(content.entries as BundleEntry[], resource.medicationReference.reference) as Medication;
+        }
+      }
+    }
+  }
 </script>
 
 <Badge color="secondary">{resource.intent ? resource.intent : ''}</Badge>
-<Badge color={resource.status === "stopped" ? "secondary" : "primary"}>{resource.status ? `${resource.status}` : ''}</Badge>
-<br>
+<Badge color={resource.status === 'stopped' ? 'secondary' : 'primary'}
+  >{resource.status ? `${resource.status}` : ''}</Badge
+>
+<br />
 {#if resource.medicationCodeableConcept}
-    {#if resource.medicationCodeableConcept.coding}
-        {#if resource.medicationCodeableConcept.coding[0].system && resource.medicationCodeableConcept.coding[0].code}
-            <Badge color="primary">{resource.medicationCodeableConcept.coding[0].system} : {resource.medicationCodeableConcept.coding[0].code}</Badge>
-            <br>
-        {/if}
-        {#if resource.medicationCodeableConcept.coding[0].display}
-            <strong>{resource.medicationCodeableConcept.coding[0].display}</strong><br>
-        {:else if resource.medicationCodeableConcept.text}
-            <strong>{resource.medicationCodeableConcept.text}</strong><br>
-        {/if}
-    {:else if resource.medicationCodeableConcept.text}
-        <strong>{resource.medicationCodeableConcept.text}</strong><br>
+  {#if resource.medicationCodeableConcept.coding}
+    {#if resource.medicationCodeableConcept.coding[0].system && resource.medicationCodeableConcept.coding[0].code}
+      <Badge color="primary"
+        >{resource.medicationCodeableConcept.coding[0].system} : {resource.medicationCodeableConcept
+          .coding[0].code}</Badge
+      >
+      <br />
     {/if}
+    {#if resource.medicationCodeableConcept.coding[0].display}
+      <strong>{resource.medicationCodeableConcept.coding[0].display}</strong><br />
+    {:else if resource.medicationCodeableConcept.text}
+      <strong>{resource.medicationCodeableConcept.text}</strong><br />
+    {/if}
+  {:else if resource.medicationCodeableConcept.text}
+    <strong>{resource.medicationCodeableConcept.text}</strong><br />
+  {/if}
+{/if}
+
+{#if medication}
+  <MedicationTemplate content={{ resource: medication, entries: content.entries }} />
+{:else if resource.medicationReference?.display}
+  <strong>{resource.medicationReference?.display}</strong>
+  <br>
+{/if}
+
+{#if resource.authoredOn}
+  Authored: {resource.authoredOn.split('T')[0]}<br>
 {/if}
 {#if resource.dispenseRequest?.validityPeriod}
-    Valid from {resource.dispenseRequest?.validityPeriod.start}{resource.dispenseRequest?.validityPeriod.end
+  Valid: {resource.dispenseRequest?.validityPeriod.start}{resource.dispenseRequest
+    ?.validityPeriod.end
     ? ` - ${resource.dispenseRequest?.validityPeriod.end}`
     : ''}
-    <br>
+  <br />
 {/if}
 
 <Dosage dosage={resource.dosageInstruction?.[0]} />

--- a/src/lib/components/resource-templates/MedicationStatement.svelte
+++ b/src/lib/components/resource-templates/MedicationStatement.svelte
@@ -1,13 +1,33 @@
 <script lang="ts">
   import { Badge } from 'sveltestrap';
-  import type { MedicationStatement } from "fhir/r4";
+  import type { BundleEntry, Medication, MedicationStatement } from "fhir/r4";
   import Dosage from '$lib/components/resource-templates/Dosage.svelte';
-  
-  export let resource: MedicationStatement; // Define a prop to pass the data to the component
+  import MedicationTemplate from '$lib/components/resource-templates/Medication.svelte';
+  import { getEntry } from '$lib/utils/util';
+  import type { ResourceTemplateParams } from '$lib/utils/types';
+
+  export let content: ResourceTemplateParams<MedicationStatement>; // Define a prop to pass the data to the component
+
+  let resource: MedicationStatement = content.resource;
+
+  let medication: Medication | undefined;
+
+  $: {
+    if (resource) {
+      if (resource.medicationReference) {
+        if (resource.contained?.[0]?.resourceType === 'Medication') {
+          // If the medication is contained in the resource
+          medication = resource.contained[0];
+        } else if (resource.medicationReference?.reference) {
+          // If the medication is referenced
+          medication = getEntry(content.entries as BundleEntry[], resource.medicationReference.reference) as Medication;
+        }
+      }
+    }
+  }
 </script>
 {#if resource.status}
-<Badge color={resource.status === "unknown" ? "secondary" : "primary"}>{resource.status}</Badge>
-<br>
+<Badge color={resource.status === "unknown" || resource.status === "stopped" ? "secondary" : "primary"}>{resource.status}</Badge>
 {/if}
 
 {#if resource.medicationCodeableConcept}
@@ -20,22 +40,16 @@
       <strong>{resource.medicationCodeableConcept.text}</strong><br>
     {/if}
   {:else if resource.medicationCodeableConcept.text}
-    <strong>{resource.medicationCodeableConcept.text}</strong><br>
-  {/if}
-  {#if resource.medicationCodeableConcept.coding}  
-    <Badge color="primary">{resource.medicationCodeableConcept.coding[0].system} : {resource.medicationCodeableConcept?.coding[0].code}</Badge>
-    <br>
-    {#if resource.medicationCodeableConcept.coding[0].display}
-      <strong>{resource.medicationCodeableConcept.coding[0].display}</strong><br>
-    {:else if resource.medicationCodeableConcept.text}
-      <strong>{resource.medicationCodeableConcept.text}</strong><br>
+    {#if resource.status}
+      <br>
     {/if}
-  {:else if resource.medicationCodeableConcept.text}
     <strong>{resource.medicationCodeableConcept.text}</strong><br>
   {/if}
 {/if}
 
-{#if resource.medicationReference?.display}
+{#if medication}
+  <MedicationTemplate content={{ resource: medication, entries: content.entries }} />
+{:else if resource.medicationReference?.display}
   <strong>{resource.medicationReference?.display}</strong>
   <br>
 {/if}
@@ -44,12 +58,12 @@
   {resource.reasonReference?.[0].display}<br>
 {/if}
 
-{#if resource.effectivePeriod?.start}
-  Effective {resource.effectivePeriod.start}{resource.effectivePeriod.end
+<Dosage dosage={resource.dosage?.[0]} />
+
+{#if resource.effectivePeriod}
+  Effective: {resource.effectivePeriod.start ? resource.effectivePeriod.start : ''}{resource.effectivePeriod.end
     ? ` - ${resource.effectivePeriod.end}`
     : ''}
 {:else if resource.effectiveDateTime}
-  {resource.effectiveDateTime ? `Effective date: ${resource.effectiveDateTime.split("T")[0]}` : ''}
+  Date: {resource.effectiveDateTime.split("T")[0]}
 {/if}
-
-<Dosage dosage={resource.dosage?.[0]} />

--- a/src/lib/components/resource-templates/Observation.svelte
+++ b/src/lib/components/resource-templates/Observation.svelte
@@ -1,12 +1,53 @@
 <script lang="ts">
   import { Badge } from 'sveltestrap';
-  import type { Observation } from "fhir/r4";
+  import type { BundleEntry, Observation } from "fhir/r4";
+  import type { ResourceTemplateParams } from '$lib/utils/types';
+  import { getEntry } from '$lib/utils/util';
   
-  export let resource: Observation; // Define a prop to pass the data to the component
+  export let content: ResourceTemplateParams<Observation>; // Define a prop to pass the data to the component
+  export let contained: Boolean = false;
+
+  let resource: Observation = content.resource;
+
+
+  interface ResolvedMember {
+    resource?: Observation;
+    display?: string;
+  }
+  let members: ResolvedMember[] | undefined = [];
+
+$: {
+  if (resource) {
+    if (resource.hasMember) {
+      for (let member of resource.hasMember) {
+        let memberFields: ResolvedMember = {};
+        if (member.reference) {
+          let memberResource;
+          if (resource.contained?.[0]?.resourceType === 'Observation') {
+            // If the member observation is contained in the resource
+            memberResource = resource.contained[0];
+          } else {
+            // If the member observation is referenced
+            memberResource = getEntry(content.entries as BundleEntry[], member.reference) as Observation;
+          }
+          if (memberResource) {
+            memberFields.resource = memberResource;
+          }
+        }
+        if (member.display) {
+          memberFields.display = member.display;
+        }
+        if (Object.keys(memberFields).length > 0) {
+          members.push(memberFields);
+        }
+      }
+    }
+  }
+}
 </script>
 
-{#if resource.category?.[0].coding}
-  <Badge color="primary">{resource.category[0].coding[0].code}</Badge><br>
+{#if !contained && resource.category?.[0].coding}
+  <Badge color="primary">{resource.category[0].coding[0].code}</Badge>
 {/if}
 {#if resource.code}
   {#if resource.code.coding}
@@ -18,19 +59,51 @@
       <strong>{resource.code.text}: </strong>
     {/if}
   {:else if resource.code.text}
-    <strong>{resource.code.text}: </strong>
+    <br><strong>{resource.code.text}: </strong>
   {/if}
 {/if}
 {#if resource.valueCodeableConcept?.coding?.[0].display}
-  <strong>{resource.valueCodeableConcept.coding[0].display}</strong><br>
+  {resource.valueCodeableConcept.coding[0].display}<br>
 {/if}
 {#if resource.valueQuantity}
-  <strong>{resource.valueQuantity.value ?? ""} {resource.valueQuantity.unit ?? ""}</strong><br>
+  {resource.valueQuantity.value ?? ""} {resource.valueQuantity.unit ?? ""}<br>
 {/if}
 {#if resource.valueString}
-  <strong>{resource.valueString ?? ""}</strong><br>
+  {resource.valueString ?? ""}<br>
+{/if}
+{#if resource.note}
+ {#each resource.note as note}
+  {#if note.text}
+    Note: {note.text}<br>
+  {/if}
+ {/each}
 {/if}
 {#if !(resource.valueCodeableConcept || resource.valueQuantity || resource.valueString)}
-<br>
+  <br>
 {/if}
-Date: {resource.effectiveDateTime ? `${resource.effectiveDateTime.split("T")[0]}` : ''}
+{#if members.length > 0}
+<table class="table table-bordered table-sm">
+  <thead>
+    <tr><th>Result(s)</th></tr>
+  </thead>
+  <tbody>
+  {#each members as member}
+    <tr>
+      <div class="mx-4">
+        {#if member.resource}
+          <svelte:self
+            content={{ resource: member.resource, entries: content.entries }}
+            contained={resource.effectiveDateTime !== undefined || resource.effectivePeriod !== undefined}
+          />
+        {:else if member.display}
+          <strong>{member.display}</strong>
+        {/if}
+      </div>
+    </tr>
+  {/each}
+  </tbody>
+</table>
+{/if}
+{#if resource.effectiveDateTime}
+  Date: {resource.effectiveDateTime.split("T")[0]}
+{/if}

--- a/src/lib/components/resource-templates/OccupationalData.svelte
+++ b/src/lib/components/resource-templates/OccupationalData.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
     import { Badge } from 'sveltestrap';
     import type { Observation } from "fhir/r4";
+    import type { ResourceTemplateParams } from '$lib/utils/types';
     
-    export let resource: Observation; // Define a prop to pass the data to the component
+    export let content: ResourceTemplateParams<Observation>; // Define a prop to pass the data to the component
+    let resource: Observation = content.resource;
   </script>
 
   {#if resource.code.coding?.[0].code}

--- a/src/lib/components/resource-templates/Organization.svelte
+++ b/src/lib/components/resource-templates/Organization.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
   import type { Organization } from "fhir/r4";
+  import type { ResourceTemplateParams } from '$lib/utils/types';
   
-  export let resource: Organization; // Define a prop to pass the data to the component
+  export let content: ResourceTemplateParams<Organization>; // Define a prop to pass the data to the component
+  let resource: Organization = content.resource;
 </script>
 
 <strong>{resource.name}</strong>

--- a/src/lib/components/resource-templates/Patient.svelte
+++ b/src/lib/components/resource-templates/Patient.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
   import { Badge } from 'sveltestrap';
   import type { Patient } from "fhir/r4";
+  import type { ResourceTemplateParams } from '$lib/utils/types';
   
-  export let resource: Patient; // Define a prop to pass the data to the component
+  export let content: ResourceTemplateParams<Patient>; // Define a prop to pass the data to the component
+  let resource: Patient = content.resource;
 </script>
 
 {#if resource.name}

--- a/src/lib/components/resource-templates/Patient.svelte
+++ b/src/lib/components/resource-templates/Patient.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
-  import { Badge } from 'sveltestrap';
-  import type { Patient } from "fhir/r4";
-  import type { ResourceTemplateParams } from '$lib/utils/types';
-  
-  export let content: ResourceTemplateParams<Patient>; // Define a prop to pass the data to the component
-  let resource: Patient = content.resource;
+    import { Badge, Button, Icon } from 'sveltestrap';
+    import type { Patient } from "fhir/r4";
+    import type { ResourceTemplateParams } from '$lib/utils/types';
+
+    export let content: ResourceTemplateParams<Patient>; // Define a prop to pass the data to the component
+    let resource: Patient = content.resource;
+
+    let showContact = false;
 </script>
 
 {#if resource.name}
@@ -23,121 +25,134 @@
     </strong>
     <br>
 {/if}
+
 {#if resource.birthDate}
     Birth Date: {resource.birthDate}<br>
 {/if}
 {#if resource.gender}
     Gender: {resource.gender ?? ""}<br>
 {/if}
-{#if resource.telecom}
-  <table class="table table-bordered table-sm">
-      <thead>
-          <tr><th colspan="3">Contact Information</th></tr>
-      </thead>
-      {#each resource.telecom as telecom}
-          <tr>
-              <td>{telecom.system ?? ""}</td>
-              <td>{telecom.use ?? ""}</td>
-              <td>{telecom.value ?? ""}</td>
-          </tr>
-      {/each}
-  </table>
-{/if}
-{#if resource.address}
-  <table class="table table-bordered table-sm">
-      <thead>
-          <tr>
-          <th scope="col">Use</th>
-          <th scope="col">Address</th>
-          </tr>
-          <tr></tr>
-      </thead>
-      {#each resource.address as address}
-          <tr>
-          <td>{address.use ?? ""}</td>
-          <td>
-              {#if address.line}
-                {#each address.line as line}
-                    {line}<br />
+{#if resource.telecom || resource.address || resource.contact}
+    <Button
+        class="my-1"
+        size="sm"
+        color={!showContact ? "secondary" : "primary"}
+        outline
+        on:click={() => showContact = !showContact}>
+        {showContact ? 'Hide' : 'Show'} contact information <Icon style="font-size: x-small;"name={!showContact ? "caret-down" : "caret-up"} />
+    </Button>
+    {#if showContact}
+        {#if resource.telecom}
+            <table class="table table-bordered table-sm">
+                <thead>
+                    <tr><th colspan="3">Contact Information</th></tr>
+                </thead>
+                {#each resource.telecom as telecom}
+                    <tr>
+                        <td>{telecom.system ?? ""}</td>
+                        <td>{telecom.use ?? ""}</td>
+                        <td>{telecom.value ?? ""}</td>
+                    </tr>
                 {/each}
-              {/if}
-              {address.city ?? "[Unknown City]"}{
-                  address.state
-                      ? `, ${address.state}`
-                      : ''
-              }{address.country
-                  ? `, ${address.country}`
-                  : ''}
-              {address.postalCode ?? ""}
-          </td>
-          </tr>
-      {/each}
-  </table>
-{/if}
-{#if resource.contact}
-  {#each resource.contact as contact}
-    <strong>Emergency Contact:</strong><br>
-    {#if contact.relationship}
-        {#each contact.relationship as relationship}
-            {#if relationship.coding && relationship.coding[0].display}
-                <Badge color="secondary">{relationship.coding[0].display}</Badge>
-            {/if}
-        {/each}
-        <br>
-    {/if}
-    {#if contact.name}
-        <strong>
-            {contact.name.prefix ?? ""}
-            {contact.name.given ? contact.name.given.join(' ') : ""}
-            {contact.name.family ?? ""}
-        </strong>
-        <br>
-    {/if}
-    {#if contact.gender}
-      Gender: {contact.gender ?? ""}<br>
-    {/if}
-    {#if contact.telecom}
-          <table class="table table-bordered table-sm">
-              <thead>
-                  <tr><th colspan="3">Contact Information</th></tr>
-              </thead>
-              {#each contact.telecom as telecom}
-                  <tr>
-                      <td>{telecom.system ?? ""}</td>
-                      <td>{telecom.use ?? ""}</td>
-                      <td>{telecom.value ?? ""}</td>
-                  </tr>
-              {/each}
-          </table>
-    {/if}
-    {#if contact.address}
-        <table class="table table-bordered table-sm">
-            <thead>
-                <tr>
-                <th scope="col">Use</th>
-                <th scope="col">Address</th>
-                </tr>
-                <tr></tr>
-            </thead>
-            <tr>
-                <td>{contact.address.use ?? ""}</td>
-                <td>
-                    {#if contact.address.line}
-                        {#each contact.address.line as line}
-                            {line}<br />
+            </table>
+        {/if}
+        {#if resource.address}
+            <table class="table table-bordered table-sm">
+                <thead>
+                    <tr>
+                    <th scope="col">Use</th>
+                    <th scope="col">Address</th>
+                    </tr>
+                    <tr></tr>
+                </thead>
+                {#each resource.address as address}
+                    <tr>
+                    <td>{address.use ?? ""}</td>
+                    <td>
+                        {#if address.line}
+                            {#each address.line as line}
+                                {line}<br />
+                            {/each}
+                        {/if}
+                        {address.city ?? "[Unknown City]"}{
+                            address.state
+                                ? `, ${address.state}`
+                                : ''
+                        }{address.country
+                            ? `, ${address.country}`
+                            : ''}
+                        {address.postalCode ?? ""}
+                    </td>
+                    </tr>
+                {/each}
+            </table>
+        {/if}
+        {#if resource.contact}
+            {#each resource.contact as contact}
+                <strong>Emergency Contact:</strong><br>
+                {#if contact.relationship}
+                    {#each contact.relationship as relationship}
+                        {#if relationship.coding && relationship.coding[0].display}
+                            <Badge color="secondary">{relationship.coding[0].display}</Badge>
+                        {/if}
+                    {/each}
+                    <br>
+                {/if}
+                {#if contact.name}
+                    <strong>
+                        {contact.name.prefix ?? ""}
+                        {contact.name.given ? contact.name.given.join(' ') : ""}
+                        {contact.name.family ?? ""}
+                    </strong>
+                    <br>
+                {/if}
+                {#if contact.gender}
+                Gender: {contact.gender ?? ""}<br>
+                {/if}
+                {#if contact.telecom}
+                    <table class="table table-bordered table-sm">
+                        <thead>
+                            <tr><th colspan="3">Contact Information</th></tr>
+                        </thead>
+                        {#each contact.telecom as telecom}
+                            <tr>
+                                <td>{telecom.system ?? ""}</td>
+                                <td>{telecom.use ?? ""}</td>
+                                <td>{telecom.value ?? ""}</td>
+                            </tr>
                         {/each}
-                    {/if}
-                    {contact.address.city ?? "[Unknown City]"}{
-                        contact.address.state
-                            ? `, ${contact.address.state}`
-                            : ''
-                    }{contact.address.country
-                        ? `, ${contact.address.country}`
-                        : ''}
-                    {contact.address.postalCode ?? ""}
-                </td>
-                </tr>
-        </table>
+                    </table>
+                {/if}
+                {#if contact.address}
+                    <table class="table table-bordered table-sm">
+                        <thead>
+                            <tr>
+                            <th scope="col">Use</th>
+                            <th scope="col">Address</th>
+                            </tr>
+                            <tr></tr>
+                        </thead>
+                        <tr>
+                            <td>{contact.address.use ?? ""}</td>
+                            <td>
+                                {#if contact.address.line}
+                                    {#each contact.address.line as line}
+                                        {line}<br />
+                                    {/each}
+                                {/if}
+                                {contact.address.city ?? "[Unknown City]"}{
+                                    contact.address.state
+                                        ? `, ${contact.address.state}`
+                                        : ''
+                                }{contact.address.country
+                                    ? `, ${contact.address.country}`
+                                    : ''}
+                                {contact.address.postalCode ?? ""}
+                            </td>
+                            </tr>
+                    </table>
+                {/if}
+            {/each}
+        {/if}
     {/if}
-  {/each}
 {/if}

--- a/src/lib/components/resource-templates/Practitioner.svelte
+++ b/src/lib/components/resource-templates/Practitioner.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
     import type { Practitioner } from "fhir/r4";
+    import type { ResourceTemplateParams } from '$lib/utils/types';
+    
+    export let content: ResourceTemplateParams<Practitioner>; // Define a prop to pass the data to the component
 
-    export let resource: Practitioner; // Define a prop to pass the data to the component
+    let resource: Practitioner = content.resource;
+
 </script>
   
 {#if resource.name}

--- a/src/lib/components/resource-templates/Procedure.svelte
+++ b/src/lib/components/resource-templates/Procedure.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
   import { Badge } from 'sveltestrap';
   import type { Procedure } from "fhir/r4";
+  import type { ResourceTemplateParams } from '$lib/utils/types';
   
-  export let resource: Procedure; // Define a prop to pass the data to the component
+  export let content: ResourceTemplateParams<Procedure>; // Define a prop to pass the data to the component
+  let resource: Procedure = content.resource;
 </script>
 
 {#if resource.code}
@@ -19,13 +21,17 @@
   {/if}
 {/if}
 {#if resource.performedDateTime}
-  Performed {resource.performedDateTime.split("T")[0]}
+  Performed: {resource.performedDateTime.split("T")[0]}
 {:else if resource.performedPeriod}
-  Performed {resource.performedPeriod}
+  Performed: {resource.performedPeriod.start ? resource.performedPeriod.start : ''}{resource.performedPeriod.end
+    ? ` - ${resource.performedPeriod.end}`
+    : ''}
 {:else if resource.performedString}
-  Performed {resource.performedString}
+  Performed: {resource.performedString}
 {:else if resource.performedAge}
-  Performed age {resource.performedAge}
+  Performed age: {resource.performedAge.value}{resource.performedAge.code}
 {:else if resource.performedRange}
-  Performed age {resource.performedRange}
+  Performed age: {resource.performedRange.low ? resource.performedRange.low : ''}{resource.performedRange.high
+    ? ` - ${resource.performedRange.high}`
+    : ''}
 {/if}

--- a/src/lib/components/viewer/IPSContent.svelte
+++ b/src/lib/components/viewer/IPSContent.svelte
@@ -298,7 +298,7 @@
   /* Limit height for section content window */
   :global(.ips-section > .accordion-collapse > .accordion-body) {
     overflow: auto !important;
-    max-height: 40rem !important;
+    max-height: 50rem !important;
   }
 
   .code {

--- a/src/lib/components/viewer/IPSContent.svelte
+++ b/src/lib/components/viewer/IPSContent.svelte
@@ -2,9 +2,13 @@
   import {
     Accordion,
     AccordionItem,
+    Button,
+    ButtonGroup,
     Card,
     CardBody,
     Col,
+    Icon,
+    Offcanvas,
     Row,
   } from 'sveltestrap';
   import type {
@@ -13,13 +17,15 @@
     CompositionSection,
     Resource
   } from "fhir/r4";
+  import { download } from '$lib/utils/util.js';
 
-  export let content: Bundle;
+  export let bundle: Bundle;
   export let mode: string;
 
   import AdvanceDirective from '$lib/components/resource-templates/AdvanceDirective.svelte';
   import AllergyIntolerance from '$lib/components/resource-templates/AllergyIntolerance.svelte';
   import Condition from '$lib/components/resource-templates/Condition.svelte';
+  import Consent from '$lib/components/resource-templates/Consent.svelte';
   import DiagnosticReport from '$lib/components/resource-templates/DiagnosticReport.svelte';
   import Encounter from '$lib/components/resource-templates/Encounter.svelte';
   import Immunization from '$lib/components/resource-templates/Immunization.svelte';
@@ -37,7 +43,7 @@
   const components: Record<string, any> = {
     "AllergyIntolerance": AllergyIntolerance,
     "Condition": Condition,
-    "Consent": AdvanceDirective,
+    "Consent": Consent,
     "DiagnosticReport": DiagnosticReport,
     "DocumentReference": AdvanceDirective,
     "Encounter": Encounter,
@@ -63,8 +69,8 @@
 
   let ipsContent: Record<string, IpsContent> = {};
   $: {
-    if (content) {
-      ipsContent = getIpsContent(content);
+    if (bundle) {
+      ipsContent = getIpsContent(bundle);
     }
   }
 
@@ -74,6 +80,14 @@
     let compositions = ips.entry?.filter((entry) => entry.resource?.resourceType === 'Composition');
     if (!compositions || !compositions[0]) {
       return content;
+    }
+    let patient = ips.entry?.filter((entry) => entry.resource?.resourceType === 'Patient').map((entry) => entry.resource);
+    if (patient?.[0]) {
+      content ["Patient"] = {
+        section: {},
+        entries: patient as Resource[],
+        useText: false
+      }
     }
     let composition = compositions[0].resource as Composition;
     composition.section?.forEach((section) => {
@@ -138,32 +152,94 @@
     showInfo = false;
     infoMessage = "";
   }
+
+  let json = "";
+  let resourceType = "";
+  let isOpen = false;
+  function setJson(resource:any) {
+      json = JSON.stringify(resource, null, 2);
+      resourceType = resource.resourceType;
+      isOpen = true;
+  }
+  function toggle() {
+      isOpen = !isOpen;
+  }
 </script>
+
+<Offcanvas
+    {isOpen}
+    {toggle}
+    scroll={false}
+    header={resourceType + " JSON"}
+    placement="end"
+    title={resourceType + " JSON"}
+    style="display: flex;  overflow-y:hidden; height: 100dvh;"
+>
+    <Row class="d-flex" style="height: 100%">
+            <Row class="d-flex pe-0" style="height:calc(100% - 50px)">
+                <Col class="d-flex pe-0" style="height:100%">
+                    <div class="d-flex pe-0 pb-0 code-container">
+                        <pre class="code"><code>{json}</code></pre>
+                    </div>
+                </Col>
+            </Row>
+            <Row class="d-flex pe-0" style="height:50px">
+                <Col class="d-flex justify-content-start align-items-end" style="padding-top: 1rem">
+                    <ButtonGroup>
+                        <Button
+                            size="sm"
+                            color="primary"
+                            on:click={() => navigator.clipboard.writeText(json)}
+                        ><Icon name="clipboard" /> Copy</Button>
+                        <Button
+                            size="sm"
+                            outline
+                            color="secondary"
+                            on:click={() => download(resourceType + ".json", json)}
+                        ><Icon name="download" /> Download</Button>
+                      </ButtonGroup>
+                </Col>
+            </Row>
+    </Row>
+</Offcanvas>
 
 {#if showInfo}
   <Row class="text-info">{infoMessage}</Row>
 {/if}
-{#each Object.entries(ipsContent) as [title, content]}
+{#each Object.entries(ipsContent) as [title, sectionContent]}
 <Row class="mx-0">
   <!--wrap in accordion with title-->
   <Accordion class="mt-3">
     <AccordionItem active class="ips-section">
       <h6 slot="header" class="my-2">{title}</h6>
-      {#if content.useText || mode === "text"}
-        {@html content.section.text?.div}
+      {#if sectionContent.useText || mode === "text"}
+        {@html sectionContent.section.text?.div}
       {:else}
         <Card style="width: 100%; max-width: 100%" class="mb-2">
-            {#each content.entries as resource, index}
+            {#each sectionContent.entries as resource, index}
               <CardBody class={index > 0 ? "border-top" : ""}>
-                <Row style="overflow:hidden">
-                  <Col>
+                <Row style="overflow:hidden" class="d-flex justify-content-end align-content-center">
+                  <Col class="flex-grow-1" style="overflow:hidden">
                     {#if mode === "app" && resource.resourceType in components}
-                      <svelte:component this={components[resource.resourceType]} resource={resource} />
+                      <svelte:component
+                        this={components[resource.resourceType]}
+                        content={{resource: resource, entries: bundle.entry}}
+                      />
                     {:else}
                       {#if mode === "app"}
                         {showInfoMessage(`Unsupported sections displayed using composition narratives`)};
                       {/if}
                     {/if}
+                  </Col>
+                  <Col class="d-flex flex-row-reverse justify-content-end align-items-start" style="max-width: max-content">
+                    <Button
+                        size="sm"
+                        color="secondary"
+                        outline
+                        on:click={() => setJson(resource)}
+                    >
+                      View
+                    </Button>
                   </Col>
                 </Row>
               </CardBody>
@@ -182,10 +258,14 @@
     width: 100% !important;
   }
 
-  :global(.ips-section th, td) {
+  :global(.ips-section th) {
     border: 1px solid lightgray !important;
     padding: 0 7px !important;
     text-align: center !important;
+  }
+
+  :global(.ips-section td) {
+    margin-left: 2em !important;
   }
 
   :global(.ips-section thead) {
@@ -196,9 +276,11 @@
   /* Alternating table row coloring */
   :global(.ips-section tbody tr:nth-child(odd)) {
     background-color: #fff;
+    border: 1px solid lightgray;
   }
   :global(.ips-section tbody tr:nth-child(even)) {
     background-color: #e7f1ff;
+    border: 1px solid lightgray;
   }
   
   /* Sticky table header */
@@ -219,4 +301,18 @@
     max-height: 40rem !important;
   }
 
+  .code {
+        overflow:auto;
+        margin: 0;
+        padding: 10px;
+    }
+    .code-container {
+        background-color: #f5f5f5;
+        border-radius: 10px;
+        border: 1px solid rgb(200, 200, 200);
+        overflow: hidden;
+    }
+    :global(div.offcanvas-body) {
+        overflow-y: hidden !important;
+    }
 </style>

--- a/src/lib/utils/IPSResourceCollection.ts
+++ b/src/lib/utils/IPSResourceCollection.ts
@@ -259,8 +259,7 @@ export class IPSResourceCollection {
                 delete rBT[sectionKey];
             }
         });
-        let selectedIPSResources = Object.values(rBT)
-            .flatMap(types => Object.values(types))
+        let selectedIPSResources = this.flattenResources(rBT)
             .filter(resource => (resource as ResourceHelper).include ) as ResourceHelper[];
         return selectedIPSResources;
     }

--- a/src/lib/utils/IPSResourceCollection.ts
+++ b/src/lib/utils/IPSResourceCollection.ts
@@ -265,6 +265,10 @@ export class IPSResourceCollection {
         return selectedIPSResources;
     }
 
+    flattenResources(resourcesByType: Record<string, Record<string, ResourceHelper>>) {
+        return Object.values(resourcesByType).flatMap(types => Object.values(types))
+    }
+
     toJson(): string {
         let resourcesByType = get(this.resourcesByType);
         let extensionSections = get(this.extensionSections);

--- a/src/lib/utils/types.ts
+++ b/src/lib/utils/types.ts
@@ -1,4 +1,4 @@
-import type { Bundle, CompositionSection, DocumentReference } from 'fhir/r4';
+import type { Bundle, BundleEntry, CompositionSection, DocumentReference } from 'fhir/r4';
 
 export interface SHLSubmitEvent {
   shcs: SHCFile[];
@@ -7,6 +7,12 @@ export interface SHLSubmitEvent {
   passcode?: string;
   exp?: number;
   patientName?: string;
+}
+
+
+export interface ResourceTemplateParams<T> {
+  resource: T;
+  entries?: BundleEntry[];
 }
 
 export interface ResourceRetrieveEvent {

--- a/src/lib/utils/util.ts
+++ b/src/lib/utils/util.ts
@@ -30,9 +30,12 @@ export function getEntry(entries: Array<BundleEntry>, reference: string) {
       // Attempt to match based on resource and uuid
       let splitReference = reference.split('/');
       let referenceId = splitReference?.pop();
-      let referenceResourceType = splitReference?.pop();
-      if (referenceResourceType === entry.resource?.resourceType && referenceId && entry.fullUrl?.includes(referenceId)) {
-        return entry.resource;
+      if (entry.resource?.resourceType && splitReference.includes(entry.resource?.resourceType) && referenceId) {
+        if (entry.fullUrl?.includes(referenceId)) {
+          return entry.resource;
+        } else if (entry.resource?.id?.includes(referenceId)) {
+          return entry.resource;
+        }
       }
     }
   }

--- a/src/lib/utils/util.ts
+++ b/src/lib/utils/util.ts
@@ -17,6 +17,32 @@ export async function base64toBlob(base64:string, type="application/octet-stream
   return window.URL.createObjectURL(await result.blob());
 }
 
+// For machine-readable content, use the reference in the Composition.section.entry to retrieve resource from Bundle
+export function getEntry(entries: Array<BundleEntry>, reference: string) {
+  let result;
+  if (!entries) {
+    return result;
+  }
+  for (let entry of entries) {
+    if (entry.fullUrl?.includes(reference)) {
+      return entry.resource;
+    } else {
+      // Attempt to match based on resource and uuid
+      let splitReference = reference.split('/');
+      let referenceId = splitReference?.pop();
+      let referenceResourceType = splitReference?.pop();
+      if (referenceResourceType === entry.resource?.resourceType && referenceId && entry.fullUrl?.includes(referenceId)) {
+        return entry.resource;
+      }
+    }
+  }
+
+  if (!result) {
+    console.log(`missing reference ${reference}`);
+  }
+  return result;
+};
+
 export function download(filename:string, text:string) {
   var element = document.createElement('a');
   element.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(text));

--- a/src/routes/(viewer)/ips/+page.svelte
+++ b/src/routes/(viewer)/ips/+page.svelte
@@ -230,19 +230,19 @@
     {#each shlContents as contents, index}
       <TabPane class={`ips${index}`} tabId={`ips${index}`} active={index === 0} style="padding-top:10px">
         <span class="smart-tab" slot="tab">{getTabLabel(contents)}</span>
-        <IPSContent content={contents} mode={$displayMode} />
+        <IPSContent bundle={contents} mode={$displayMode} />
       </TabPane>
     {/each}
     {#if SHOW_VIEWER_DEMO}
       <TabPane tabId="demo" active={shlContents.length === 0} style="padding-top:10px">
         <span class="demo-tab" slot="tab">IPS Demo</span>
-        <Demo content={shlContents[0]} mode={$displayMode} />
+        <Demo bundle={shlContents[0]} mode={$displayMode} />
       </TabPane>
     {/if}
   </TabContent>
 {:else}
   <!-- Single tab view -->
-  <IPSContent content={shlContents[0]} mode={$displayMode} />
+  <IPSContent bundle={shlContents[0]} mode={$displayMode} />
 {/if}
 
 <style lang="css">


### PR DESCRIPTION
Bring in changes to the IPS viewer based on testing at the January '25 connectathon. Since being converted to use svelte components, the WA Verify+ viewer was altered for use on [ipsviewer.com](https://ipsviewer.com) where it received testing and feedback during the connectathon's IPS track testing. The changes that came from that feedback are integrated back into the WA Verify+ viewer and template files in this PR, including:
- Resource template updates:
    - Patient template added
    - Referenced resource support for appropriate templates
    - Misc. field display fixes
- Layout and mobile view improvements
- Viewer demo enhancements (statistic box, input ui behavior)
- Source JSON view buttons