### PR TITLE
Preload banner images for qr image construction

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -10,6 +10,8 @@
     <link rel="preload" as="font" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.9.1/font/fonts/bootstrap-icons.woff2?8d200481aa7f02a2d63a331fc782cfaf" type="font/woff2" crossorigin="anonymous">
     <link rel="preload" as="image" href="/img/doh_logo_doh-black.png" />
     <link rel="preload" as="image" href="/img/waverifypluslogo.svg" />
+    <link rel="preload" as="image" href="/img/qr-banner-top.png" />
+    <link rel="preload" as="image" href="/img/qr-banner-bottom.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
 
     %sveltekit.head%


### PR DESCRIPTION
Addresses bug where qr image doesn't load if banner images aren't cached