### PR TITLE
Fix server file API_BASE value for non-dev deploys

### DIFF
--- a/src/lib/server/config.ts
+++ b/src/lib/server/config.ts
@@ -1,5 +1,7 @@
 export const AUTOCODER_API_KEY = process.env.AUTOCODER_API_KEY;
 
+export const API_BASE = process.env.VITE_API_BASE;
+
 export const REDIRECT_URI = process.env.REDIRECT_URI;
 
 export const SERVER_API_BASE = process.env.VITE_API_BASE;

--- a/src/routes/(app)/view/[id]/+page.server.ts
+++ b/src/routes/(app)/view/[id]/+page.server.ts
@@ -1,7 +1,7 @@
 import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from '$types';
 import type { SHLAdminParams } from '$lib/utils/managementClient';
-import { API_BASE } from '$lib/config/config.ts';
+import { API_BASE } from '$lib/server/config';
 import { getUserShls } from '$lib/utils/shlServerUtils';
 
 


### PR DESCRIPTION
Prod instances use the client window.___env to get their public config, so the server files don't have access to the client config like dev instances do.
Fix: add the value to the server-only config and import it from there.