### PR TITLE
Fix for language menu in collapsed nav

### DIFF
--- a/src/lib/components/layout/LanguageMenu.svelte
+++ b/src/lib/components/layout/LanguageMenu.svelte
@@ -5,7 +5,7 @@
 </script>
 
 <Dropdown nav inNavbar class="navbar-dropdown" size="sm" direction="down">
-  <DropdownToggle color="primary" class="pt-0" nav caret>
+  <DropdownToggle color="primary" class="header-link pt-0" nav caret>
     <span style="font-size:small">
       {locales[$locale].lang} <Icon name="globe2" />
     </span>


### PR DESCRIPTION
Add header-link class to allow language menu to be opened in collapsed nav