### PR TITLE
Await layout server load function in /view load to prevent attempting…

### DIFF
--- a/src/routes/(app)/view/[id]/+page.server.ts
+++ b/src/routes/(app)/view/[id]/+page.server.ts
@@ -5,17 +5,21 @@ import { API_BASE } from '$lib/server/config';
 import { getUserShls } from '$lib/utils/shlServerUtils';
 
 
-export const load: PageServerLoad = async ({ params, locals }) => {
+export const load: PageServerLoad = async ({ params, locals, parent }) => {
+  // Wait for layout data — if unauthenticated, don't bother loading
+  const parentData = await parent();
+  if (parentData.unauthenticated) {
+    return { shl: null };
+  }
+
   const shls = await getUserShls(API_BASE, locals.token);
   if (!Array.isArray(shls)) {
     console.error("SHLs aren't array");
     return { shl: null };
   }
   const shl = shls.find((shl: SHLAdminParams) => shl.id === params.id);
-
-  if (locals.token && !shl) {
+  if (!shl) {
     throw error(404, 'Health link not found');
   }
-
   return { shl };
 };

--- a/src/routes/(app)/view/[id]/+page.svelte
+++ b/src/routes/(app)/view/[id]/+page.svelte
@@ -16,7 +16,7 @@
     <link rel="preload" as="image" href={`${INSTANCE_CONFIG.imgPath}/qr-banner-bottom.png`} />
 </svelte:head>
 
-{#if data.unauthenticated || !data.shl}
+{#if data.unauthenticated || data.shl === undefined || data.shl === null}
 <!-- Render nothing or a spinner while auth recovery runs -->
   <div>Loading...</div>
 {:else}


### PR DESCRIPTION
… a load while still unauthenticated.

Was causing /view to hang on "Loading..." message particularly when new SHLs were being created or after periods of inactivity.