### PR TITLE
Fix PWA manifest path, which shouldn't be relative

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -8,7 +8,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/font/bootstrap-icons.min.css">
     <link rel="font" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/font/fonts/bootstrap-icons.woff2" type="font/woff2" crossorigin="anonymous">
-    <link rel="manifest" crossorigin="use-credentials" href="manifest.json" />
+    <link rel="manifest" crossorigin="use-credentials" href="/manifest.json" />
     <script src="/window.env.js"></script>
     %sveltekit.head%
   </head>


### PR DESCRIPTION
Cleans up console errors for non-homepage routes.