### PR TITLE
Hotfixes for insurance and data loading

### DIFF
--- a/src/lib/components/app/FetchCARINBB.svelte
+++ b/src/lib/components/app/FetchCARINBB.svelte
@@ -104,7 +104,7 @@
         return fetch(`${sofHost!.url}/${reference}`, {
           headers: headers
         }).then(response => response.json());
-      }))).filter(x => x.status == "fulfilled" && x.value.resourceType).map(x => x.value);
+      }))).filter(x => x.status == "fulfilled" && x.value.resourceType && x.value.resourceType !== "OperationOutcome").map(x => x.value);
       allResources = allResources.concat(...resources);
       referenceMap = {};
       depth--;

--- a/src/lib/components/app/FetchCARINBB.svelte
+++ b/src/lib/components/app/FetchCARINBB.svelte
@@ -104,7 +104,7 @@
         return fetch(`${sofHost!.url}/${reference}`, {
           headers: headers
         }).then(response => response.json());
-      }))).filter(x => x.status == "fulfilled").map(x => x.value);
+      }))).filter(x => x.status == "fulfilled" && x.value.resourceType).map(x => x.value);
       allResources = allResources.concat(...resources);
       referenceMap = {};
       depth--;

--- a/src/lib/components/resource-templates/Observation.svelte
+++ b/src/lib/components/resource-templates/Observation.svelte
@@ -26,34 +26,37 @@
     resource?: Observation;
     display?: string;
   }
-  let members: ResolvedMember[] | undefined = [];
+  let members: ResolvedMember[] = [];
 
   $: {
-    if (resource) {
-      if (resource.hasMember) {
-        for (let member of resource.hasMember) {
-          let memberFields: ResolvedMember = {};
-          if (member.reference) {
-            let memberResource;
-            if (resource.contained?.[0]?.resourceType === 'Observation') {
-              // If the member observation is contained in this resource
-              memberResource = resource.contained[0];
-            } else {
-              // If the member observation is a bundle reference
-              memberResource = getEntry(content.entries as BundleEntry[], member.reference) as Observation;
-            }
-            if (memberResource) {
-              memberFields.resource = memberResource;
-            }
+    if (resource?.hasMember) {
+      members = resource.hasMember.reduce<ResolvedMember[]>((acc, member) => {
+        let memberFields: ResolvedMember = {};
+  
+        if (member.reference) {
+          let memberResource: Observation | undefined;
+          if (resource.contained?.[0]?.resourceType === 'Observation') {
+            memberResource = resource.contained[0] as Observation;
+          } else {
+            memberResource = getEntry(content.entries as BundleEntry[], member.reference) as Observation;
           }
-          if (member.display) {
-            memberFields.display = member.display;
-          }
-          if (Object.keys(memberFields).length > 0) {
-            members.push(memberFields);
+          if (memberResource) {
+            memberFields.resource = memberResource;
           }
         }
-      }
+  
+        if (member.display) {
+          memberFields.display = member.display;
+        }
+  
+        if (Object.keys(memberFields).length > 0) {
+          acc.push(memberFields);
+        }
+  
+        return acc;
+      }, []);
+    } else {
+      members = [];
     }
   }
 </script>
@@ -96,7 +99,7 @@
             {#if member.resource}
               <svelte:self
                 content={{ resource: member.resource, entries: content.entries }}
-                contained={hasChoiceDTField("effective", resource)}
+                contained={hasChoiceDTField("effective", member.resource)}
               />
             {:else if member.display}
               <strong>{member.display}</strong>


### PR DESCRIPTION
  Fixes some breaking issues in the test branch
  
  - Insurance interactions - when insurance APIs return http failures or http successes with failure OperationOutcome resources, don't include them in the dataset upload.
  - Fix bug in observation resource template
