### PR TITLE
Changes for the 2026-07 CMS Connectathon's PACIO tracks.

### DIFF
--- a/src/lib/components/app/AddFilePOLST.svelte
+++ b/src/lib/components/app/AddFilePOLST.svelte
@@ -382,22 +382,22 @@
                         url: "https://qa-rr-fhir.maxmddirect.com",
                         patients: [
                           {
-                            last: "Mosley",
-                            //last: "Smith-Johnson",
-                            first: "Jenny",
-                            //first: "Betsy",
-                            gender: "female",
-                            dob: "1955-10-03",
-                            //dob: "1950-11-15",
-                          },
-                          {
-                            // last: "Mosley",
+                            //last: "Mosley",
                             last: "Smith-Johnson",
-                            // first: "Jenny",
+                            //first: "Jenny",
                             first: "Betsy",
                             gender: "female",
-                            // dob: "1955-10-03",
+                            //dob: "1955-10-03",
                             dob: "1950-11-15",
+                          },
+                          {
+                            last: "Mosley",
+                            // last: "Smith-Johnson",
+                            first: "Jenny",
+                            // first: "Betsy",
+                            gender: "female",
+                            dob: "1955-10-03",
+                            // dob: "1950-11-15",
                           }
                         ],
                         patient: writable({})

--- a/src/lib/components/app/AdvancedDirectiveSearch.svelte
+++ b/src/lib/components/app/AdvancedDirectiveSearch.svelte
@@ -79,22 +79,22 @@
       url: "https://qa-rr-fhir.maxmddirect.com",
       patients: [
         {
-          last: "Mosley",
-          //last: "Smith-Johnson",
-          first: "Jenny",
-          //first: "Betsy",
-          gender: "female",
-          dob: "1955-10-03",
-          //dob: "1950-11-15",
-        },
-        {
-          // last: "Mosley",
+          //last: "Mosley",
           last: "Smith-Johnson",
-          // first: "Jenny",
+          //first: "Jenny",
           first: "Betsy",
           gender: "female",
-          // dob: "1955-10-03",
+          //dob: "1955-10-03",
           dob: "1950-11-15",
+        },
+        {
+          last: "Mosley",
+          // last: "Smith-Johnson",
+          first: "Jenny",
+          // first: "Betsy",
+          gender: "female",
+          dob: "1955-10-03",
+          // dob: "1950-11-15",
         }
       ],
       patient: writable({})

--- a/src/lib/components/app/DataSummary.svelte
+++ b/src/lib/components/app/DataSummary.svelte
@@ -15,6 +15,8 @@
   import {getFriendlySourceNameBySource} from '$lib/utils/resourceCollectionUtils';
   import { createCategorizedStore, type CategoryMap } from '$lib/stores/categorizedResources';
   import ResourceDisplay from '$lib/components/app/ResourceDisplay.svelte';
+  import ObservationSparkline from '$lib/components/app/ObservationSparkline.svelte';
+  import { buildObservationSeriesMap, sparklineSeriesFor } from '$lib/utils/observationSparkline';
   import { derived, type Readable } from 'svelte/store';
   import { goto } from '$app/navigation';
 
@@ -104,6 +106,7 @@
     {#if $categoryDataToDisplay[category] && Object.keys($categoryDataToDisplay[category]).length > 0}
       {@const values = Object.values($categoryDataToDisplay[category]).sort((a, b) => sortResources(a, b))}
       {@const valuesToDisplay = summary ? values.slice(0, 3) : values}
+      {@const observationSeriesMap = buildObservationSeriesMap(values)}
       <CategoryView
         class="mb-4"
         title={category}
@@ -126,6 +129,12 @@
               <Col class="ps-0 overflow-auto justify-content-center align-items-center">
                 <ResourceDisplay resource={value} entries={Object.values($categoryDataToDisplay)} />
               </Col>
+              {@const sparklineSeries = sparklineSeriesFor(value, observationSeriesMap)}
+              {#if sparklineSeries}
+                <Col class="d-flex justify-content-center align-items-center" style="flex: 0 0 auto; max-width: fit-content">
+                  <ObservationSparkline series={sparklineSeries} currentId={value.rh.tempId} />
+                </Col>
+              {/if}
               <Col class="d-flex justify-content-end align-items-center" style="max-width: fit-content">
                 {#if $mode === 'advanced'}
                   <Button

--- a/src/lib/components/app/DataSummary.svelte
+++ b/src/lib/components/app/DataSummary.svelte
@@ -15,8 +15,6 @@
   import {getFriendlySourceNameBySource} from '$lib/utils/resourceCollectionUtils';
   import { createCategorizedStore, type CategoryMap } from '$lib/stores/categorizedResources';
   import ResourceDisplay from '$lib/components/app/ResourceDisplay.svelte';
-  import ObservationSparkline from '$lib/components/app/ObservationSparkline.svelte';
-  import { buildObservationSeriesMap, sparklineSeriesFor } from '$lib/utils/observationSparkline';
   import { derived, type Readable } from 'svelte/store';
   import { goto } from '$app/navigation';
 
@@ -106,7 +104,6 @@
     {#if $categoryDataToDisplay[category] && Object.keys($categoryDataToDisplay[category]).length > 0}
       {@const values = Object.values($categoryDataToDisplay[category]).sort((a, b) => sortResources(a, b))}
       {@const valuesToDisplay = summary ? values.slice(0, 3) : values}
-      {@const observationSeriesMap = buildObservationSeriesMap(values)}
       <CategoryView
         class="mb-4"
         title={category}
@@ -127,14 +124,8 @@
                 <div class="p-0 m-0 rounded h-100" style="max-width: 0px; border: .2rem solid {$colorMap.get(sourceName)}"></div>
               </div>
               <Col class="ps-0 overflow-auto justify-content-center align-items-center">
-                <ResourceDisplay resource={value} entries={Object.values($categoryDataToDisplay)} />
+                <ResourceDisplay resource={value} entries={Object.values(values)} />
               </Col>
-              {@const sparklineSeries = sparklineSeriesFor(value, observationSeriesMap)}
-              {#if sparklineSeries}
-                <Col class="d-flex justify-content-center align-items-center" style="flex: 0 0 auto; max-width: fit-content">
-                  <ObservationSparkline series={sparklineSeries} currentId={value.rh.tempId} />
-                </Col>
-              {/if}
               <Col class="d-flex justify-content-end align-items-center" style="max-width: fit-content">
                 {#if $mode === 'advanced'}
                   <Button

--- a/src/lib/components/app/FetchAD.svelte
+++ b/src/lib/components/app/FetchAD.svelte
@@ -333,10 +333,13 @@
           let structuredFields: any = {};
 
           structuredFields.isPolst = true;
-          // In the POLST find the content[] with format.code = "urn:hl7-org:pe:adipmo-structuredBody:1.1" (ADIPMO Structured Body Bundle),
+          // In the POLST find the content[] with format.code = "urn:hl7-org:pe:adipmo-structuredBody[|Bundle]:1.1" (ADIPMO Structured Body Bundle),
           const contentAdipmoBundleRef = dr.content.find((content) => {
-            //return (content.format?.code === 'urn:hl7-org:pe:adipmo-structuredBody:1.1' && content.attachment?.url?.includes('Bundle'));
-            return (content.format?.code === 'urn:hl7-org:pe:adipmo-structuredBodyBundle:1.1' && content.attachment?.url?.includes('Bundle'));
+            return (
+              (content.format?.code === 'urn:hl7-org:pe:adipmo-structuredBodyBundle:1.1' ||
+                content.format?.code === 'urn:hl7-org:pe:adipmo-structuredBody:1.1') &&
+              content.attachment?.url?.includes('Bundle')
+            );
           });
           // look in that content's attachment.url, that will point at a Bundle (e.g. https://qa-rr-fhir2.maxmddirect.com/Bundle/10f4ff31-2c24-414d-8d70-de3a86bed808?_format=json)
           const adipmoBundleUrl = contentAdipmoBundleRef?.attachment.url;

--- a/src/lib/components/app/FetchAD.svelte
+++ b/src/lib/components/app/FetchAD.svelte
@@ -330,7 +330,9 @@
       for (let dr of resources) {
         // If this DR is a POLST, add the following chain of queries:
         if (isPolst(dr)){
-          dr.isPolst = true;
+          let structuredFields: any = {};
+
+          structuredFields.isPolst = true;
           // In the POLST find the content[] with format.code = "urn:hl7-org:pe:adipmo-structuredBody:1.1" (ADIPMO Structured Body Bundle),
           const contentAdipmoBundleRef = dr.content.find((content) => {
             return (content.format?.code === 'urn:hl7-org:pe:adipmo-structuredBody:1.1' && content.attachment?.url?.includes('Bundle'));
@@ -350,8 +352,8 @@
             // then set the appropriate flags in the DR
             (
               {
-                exists: dr.isCpr,
-                doNotPerform: dr.doNotPerformCpr
+                exists: structuredFields.isCpr,
+                doNotPerform: structuredFields.doNotPerformCpr
               } = digestServiceRequestByCode(serviceRequests, '100822-6')
             );
 
@@ -359,10 +361,10 @@
             // then set the appropriate flags in the DR
             (
               {
-                exists: dr.isComfortTreatments,
-                doNotPerform: dr.doNotPerformComfortTreatments,
-                type: dr.typeComfortTreatments,
-                detail: dr.detailComfortTreatments
+                exists: structuredFields.isComfortTreatments,
+                doNotPerform: structuredFields.doNotPerformComfortTreatments,
+                type: structuredFields.typeComfortTreatments,
+                detail: structuredFields.detailComfortTreatments
               } = digestServiceRequestByCode(serviceRequests, '100823-4')
             );
 
@@ -370,9 +372,9 @@
             // then set the appropriate flags in the DR
             (
               {
-                exists: dr.isAdditionalTx,
-                doNotPerform: dr.doNotPerformAdditionalTx,
-                detail: dr.detailAdditionalTx
+                exists: structuredFields.isAdditionalTx,
+                doNotPerform: structuredFields.doNotPerformAdditionalTx,
+                detail: structuredFields.detailAdditionalTx
               } = digestServiceRequestByCode(serviceRequests, '100824-2')
             );
 
@@ -380,12 +382,24 @@
             // then set the appropriate flags in the DR
             (
               {
-                exists: dr.isMedicallyAssisted,
-                doNotPerform: dr.doNotPerformMedicallyAssisted,
-                detail: dr.detailMedicallyAssisted
+                exists: structuredFields.isMedicallyAssisted,
+                doNotPerform: structuredFields.doNotPerformMedicallyAssisted,
+                detail: structuredFields.detailMedicallyAssisted
               } = digestServiceRequestByCode(serviceRequests, '100825-9')
             );
           }
+          
+          let extension = dr.extension || [];
+          Object.entries(structuredFields).forEach(([key, value]) => {
+            const extensionUrl = `http://fhir.cirg.uw.edu/StructuredBodyFields/${key}`;
+            if (value) {
+              extension.push({
+                url: extensionUrl,
+                valueBoolean: value
+              })
+            }
+          });
+          dr.extension = extension;
         }
       }
 

--- a/src/lib/components/app/FetchAD.svelte
+++ b/src/lib/components/app/FetchAD.svelte
@@ -335,7 +335,8 @@
           structuredFields.isPolst = true;
           // In the POLST find the content[] with format.code = "urn:hl7-org:pe:adipmo-structuredBody:1.1" (ADIPMO Structured Body Bundle),
           const contentAdipmoBundleRef = dr.content.find((content) => {
-            return (content.format?.code === 'urn:hl7-org:pe:adipmo-structuredBody:1.1' && content.attachment?.url?.includes('Bundle'));
+            //return (content.format?.code === 'urn:hl7-org:pe:adipmo-structuredBody:1.1' && content.attachment?.url?.includes('Bundle'));
+            return (content.format?.code === 'urn:hl7-org:pe:adipmo-structuredBodyBundle:1.1' && content.attachment?.url?.includes('Bundle'));
           });
           // look in that content's attachment.url, that will point at a Bundle (e.g. https://qa-rr-fhir2.maxmddirect.com/Bundle/10f4ff31-2c24-414d-8d70-de3a86bed808?_format=json)
           const adipmoBundleUrl = contentAdipmoBundleRef?.attachment.url;

--- a/src/lib/components/app/FetchAD.svelte
+++ b/src/lib/components/app/FetchAD.svelte
@@ -397,10 +397,15 @@
           Object.entries(structuredFields).forEach(([key, value]) => {
             const extensionUrl = `http://fhir.cirg.uw.edu/StructuredBodyFields/${key}`;
             if (value) {
-              extension.push({
-                url: extensionUrl,
-                valueBoolean: value
-              })
+              let newExtension: any = { url: extensionUrl };
+              if (typeof value === 'boolean') {
+                newExtension.valueBoolean = value;
+              } else if (typeof value === 'number') {
+                newExtension.valueInteger = value;
+              } else if (typeof value === 'string') {
+                newExtension.valueString = value;
+              }
+              extension.push(newExtension);
             }
           });
           dr.extension = extension;

--- a/src/lib/components/app/FetchAD.svelte
+++ b/src/lib/components/app/FetchAD.svelte
@@ -69,13 +69,13 @@
       selected: false,
       url: "https://qa-rr-fhir.maxmddirect.com",
       patient: writable({
-        last: "Mosley",
-        //last: "Smith-Johnson",
-        first: "Jenny",
-        //first: "Betsy",
+        //last: "Mosley",
+        last: "Smith-Johnson",
+        //first: "Jenny",
+        first: "Betsy",
         gender: "female",
-        dob: "1955-10-03",
-        //dob: "1950-11-15",
+        //dob: "1955-10-03",
+        dob: "1950-11-15",
       })
     },
     // "AD Vault 2025-07": { // 2025-07 Connectathon

--- a/src/lib/components/app/FetchADPOLST.svelte
+++ b/src/lib/components/app/FetchADPOLST.svelte
@@ -57,13 +57,13 @@
       selected: false,
       url: "https://qa-rr-fhir.maxmddirect.com",
       patient: writable({
-        last: "Mosley",
-        //last: "Smith-Johnson",
-        first: "Jenny",
-        //first: "Betsy",
+        //last: "Mosley",
+        last: "Smith-Johnson",
+        //first: "Jenny",
+        first: "Betsy",
         gender: "female",
-        dob: "1955-10-03",
-        //dob: "1950-11-15",
+        //dob: "1955-10-03",
+        dob: "1950-11-15",
       })
     },
   };

--- a/src/lib/components/app/FetchUrl.svelte
+++ b/src/lib/components/app/FetchUrl.svelte
@@ -18,6 +18,7 @@
   import type { SHCRetrieveEvent, IAuthService, IPSRetrieveEvent, ResourceRetrieveEvent } from '$lib/utils/types';
   import FHIRDataServiceChecker from '$lib/components/app/FHIRDataServiceChecker.svelte';
   import { getResourcesFromIPS, isIPSBundle } from '$lib/utils/util';
+  import { normalizeGad7QuestionnaireResponses } from '$lib/utils/sdcClient';
   import { METHODS, CATEGORIES } from '$lib/config/tags';
 
   export let disabled = false;
@@ -158,7 +159,8 @@
       }
 
       let result = {
-        resources: getResourcesFromIPS(content),
+        // Normalize GAD7 QuestionnaireResponses so they're ready for $extract on upload.
+        resources: normalizeGad7QuestionnaireResponses(getResourcesFromIPS(content)),
         category: CATEGORY,
         method: METHOD,
         source: hostname,

--- a/src/lib/components/app/FetchUrl.svelte
+++ b/src/lib/components/app/FetchUrl.svelte
@@ -157,10 +157,6 @@
         return shcDispatch('shc-retrieved', shcResult);
       }
 
-      if (!isIPSBundle(content)) {
-        throw Error("Error: URL must return a FHIR IPS Bundle.");
-      }
-
       let result = {
         resources: getResourcesFromIPS(content),
         category: CATEGORY,

--- a/src/lib/components/app/FetchUrl.svelte
+++ b/src/lib/components/app/FetchUrl.svelte
@@ -18,7 +18,7 @@
   import type { SHCRetrieveEvent, IAuthService, IPSRetrieveEvent, ResourceRetrieveEvent } from '$lib/utils/types';
   import FHIRDataServiceChecker from '$lib/components/app/FHIRDataServiceChecker.svelte';
   import { getResourcesFromIPS, isIPSBundle } from '$lib/utils/util';
-  import { normalizeGad7QuestionnaireResponses } from '$lib/utils/sdcClient';
+  //import { normalizeGad7QuestionnaireResponses } from '$lib/utils/sdcClient';
   import { METHODS, CATEGORIES } from '$lib/config/tags';
 
   export let disabled = false;
@@ -160,7 +160,8 @@
 
       let result = {
         // Normalize GAD7 QuestionnaireResponses so they're ready for $extract on upload.
-        resources: normalizeGad7QuestionnaireResponses(getResourcesFromIPS(content)),
+        resources: getResourcesFromIPS(content),
+        //resources: normalizeGad7QuestionnaireResponses(getResourcesFromIPS(content)),
         category: CATEGORY,
         method: METHOD,
         source: hostname,

--- a/src/lib/components/app/ObservationSparkline.svelte
+++ b/src/lib/components/app/ObservationSparkline.svelte
@@ -1,0 +1,55 @@
+<script lang="ts">
+  import type { SparklinePoint } from '$lib/utils/observationSparkline';
+
+  export let series: SparklinePoint[] = [];
+  export let currentId: string;
+
+  const width = 120;
+  const height = 32;
+  const padX = 5;
+  const padY = 6;
+
+  $: n = series.length;
+  $: ys = series.map(p => p.y);
+  $: minY = ys.length ? Math.min(...ys) : 0;
+  $: maxY = ys.length ? Math.max(...ys) : 0;
+  $: span = maxY - minY;
+
+  function xFor(i: number): number {
+    if (n <= 1) return width / 2;
+    return padX + (i * (width - 2 * padX)) / (n - 1);
+  }
+  // Higher value -> higher on the chart (smaller pixel y). Flat series centers.
+  function yFor(v: number): number {
+    if (span === 0) return height / 2;
+    return height - padY - ((v - minY) / span) * (height - 2 * padY);
+  }
+
+  $: linePoints = series.map((p, i) => `${xFor(i)},${yFor(p.y)}`).join(' ');
+</script>
+
+{#if n >= 2}
+  <svg
+    {width}
+    {height}
+    viewBox={`0 0 ${width} ${height}`}
+    role="img"
+    aria-label="Trend of values sharing this code"
+  >
+    <polyline
+      points={linePoints}
+      fill="none"
+      stroke="#6c757d"
+      stroke-width="1.5"
+      stroke-linejoin="round"
+      stroke-linecap="round"
+    />
+    {#each series as p, i}
+      {#if p.id === currentId}
+        <circle cx={xFor(i)} cy={yFor(p.y)} r="3.5" fill="#fd7e14" stroke="#fff" stroke-width="1" />
+      {:else}
+        <circle cx={xFor(i)} cy={yFor(p.y)} r="1.6" fill="#6c757d" />
+      {/if}
+    {/each}
+  </svg>
+{/if}

--- a/src/lib/components/resource-templates/AdvanceDirective.svelte
+++ b/src/lib/components/resource-templates/AdvanceDirective.svelte
@@ -123,11 +123,6 @@ Text:
   <br>
 {/if}
 
-{#if structuredFields.isPolst}
-  <b>Is POLST</b>
-  <br>
-{/if}
-
 {#if structuredFields.isPolst && (structuredFields.isCpr || structuredFields.isComfortTreatments || structuredFields.isAdditionalTx || structuredFields.isMedicallyAssisted)}
   <br>
   <b>POLST Details:</b>
@@ -147,7 +142,7 @@ Text:
       {#if structuredFields.isComfortTreatments}
         <ol>
           {#if structuredFields.doNotPerformComfortTreatments}
-            <b>This includes an order to NOT perform treatments:</b> {@html structuredFields.detailComfortTreatments}
+            <b>This includes an order to NOT perform treatments:</b> {@html structuredFields.detailComfortTreatments ?? "Unknown"}
           {:else}
             <b>This includes an order to perform {structuredFields.typeComfortTreatments ? `${structuredFields.typeComfortTreatments.toLowerCase()}` : 'treatments'}:</b> {@html structuredFields.detailComfortTreatments}
           {/if}
@@ -157,9 +152,9 @@ Text:
       {#if structuredFields.isAdditionalTx}
         <ol>
           {#if structuredFields.doNotPerformAdditionalTx}
-            <b>This includes an order to NOT perform additional treatments:</b> {@html structuredFields.detailAdditionalTx}
+            <b>This includes an order to NOT perform additional treatments:</b> {@html structuredFields.detailAdditionalTx ?? "Unknown"}
           {:else}
-            <b>This includes an order to perform additional treatments:</b> {@html structuredFields.detailAdditionalTx}
+            <b>This includes an order to perform additional treatments:</b> {@html structuredFields.detailAdditionalTx ?? "Unknown"}
           {/if}
         </ol>
       {/if}
@@ -167,9 +162,9 @@ Text:
       {#if structuredFields.isMedicallyAssisted}
         <ol>
           {#if structuredFields.doNotPerformMedicallyAssisted}
-            <b>This includes an order to NOT perform medically assisted nutrition:</b> {@html structuredFields.detailMedicallyAssisted}
+            <b>This includes an order to NOT perform medically assisted nutrition:</b> {@html structuredFields.detailMedicallyAssisted ?? "Unknown"}
           {:else}
-            <b>This includes an order to perform medically assisted nutrition:</b> {@html structuredFields.detailMedicallyAssisted}
+            <b>This includes an order to perform medically assisted nutrition:</b> {@html structuredFields.detailMedicallyAssisted ?? "Unknown"}
           {/if}
         </ol>
       {/if}

--- a/src/lib/components/resource-templates/AdvanceDirective.svelte
+++ b/src/lib/components/resource-templates/AdvanceDirective.svelte
@@ -19,16 +19,29 @@
   // Determine if any extension has the revoked status reactively
   let isRevoked = false;
 
-  // Reactive declaration to update isRevoked when resource.extension changes
+  // Collect any structured body field extension values for display
+  let structuredFields: Record<string, unknown> = {};
+
+  // Reactive declaration to update isRevoked and structuredFields when resource.extension changes
   $: {
     if (resource.extension) {
       isRevoked = resource.extension.some(
         ext => ext.url === 'http://hl7.org/fhir/us/pacio-adi/StructureDefinition/adi-document-revoke-status-extension'
         && ext.valueCoding?.code === 'cancelled'
       );
+
+      structuredFields = resource.extension.reduce((acc, ext) => {
+        if (ext.url.startsWith('http://fhir.cirg.uw.edu/StructuredBodyFields/')) {
+          let valueField = Object.keys(ext).find(key => key.startsWith('value'));
+          if (valueField) {
+            acc[ext.url.split('/').pop() as string] = ext[valueField];
+          }
+        }
+        return acc;
+      }, structuredFields);
+
     }
   }
-
 </script>
 
 <div class:is-revoked={isRevoked}>
@@ -110,14 +123,19 @@ Text:
   <br>
 {/if}
 
-{#if resource.isPolst && (resource.isCpr || resource.isComfortTreatments || resource.isAdditionalTx || resource.isMedicallyAssisted)}
+{#if structuredFields.isPolst}
+  <b>Is POLST</b>
+  <br>
+{/if}
+
+{#if structuredFields.isPolst && (structuredFields.isCpr || structuredFields.isComfortTreatments || structuredFields.isAdditionalTx || structuredFields.isMedicallyAssisted)}
   <br>
   <b>POLST Details:</b>
     <ul>
-      {#if resource.isCpr}
+      {#if structuredFields.isCpr}
         <ol>
           <b>
-            {#if resource.doNotPerformCpr}
+            {#if structuredFields.doNotPerformCpr}
               This includes an order to NOT perform CPR.
             {:else}
               This includes an order to perform CPR.
@@ -126,32 +144,32 @@ Text:
         </ol>
       {/if}
 
-      {#if resource.isComfortTreatments}
+      {#if structuredFields.isComfortTreatments}
         <ol>
-          {#if resource.doNotPerformComfortTreatments}
-            <b>This includes an order to NOT perform treatments:</b> {@html resource.detailComfortTreatments}
+          {#if structuredFields.doNotPerformComfortTreatments}
+            <b>This includes an order to NOT perform treatments:</b> {@html structuredFields.detailComfortTreatments}
           {:else}
-            <b>This includes an order to perform {resource.typeComfortTreatments ? `${resource.typeComfortTreatments.toLowerCase()}` : 'treatments'}:</b> {@html resource.detailComfortTreatments}
+            <b>This includes an order to perform {structuredFields.typeComfortTreatments ? `${structuredFields.typeComfortTreatments.toLowerCase()}` : 'treatments'}:</b> {@html structuredFields.detailComfortTreatments}
           {/if}
         </ol>
       {/if}
 
-      {#if resource.isAdditionalTx}
+      {#if structuredFields.isAdditionalTx}
         <ol>
-          {#if resource.doNotPerformAdditionalTx}
-            <b>This includes an order to NOT perform additional treatments:</b> {@html resource.detailAdditionalTx}
+          {#if structuredFields.doNotPerformAdditionalTx}
+            <b>This includes an order to NOT perform additional treatments:</b> {@html structuredFields.detailAdditionalTx}
           {:else}
-            <b>This includes an order to perform additional treatments:</b> {@html resource.detailAdditionalTx}
+            <b>This includes an order to perform additional treatments:</b> {@html structuredFields.detailAdditionalTx}
           {/if}
         </ol>
       {/if}
 
-      {#if resource.isMedicallyAssisted}
+      {#if structuredFields.isMedicallyAssisted}
         <ol>
-          {#if resource.doNotPerformMedicallyAssisted}
-            <b>This includes an order to NOT perform medically assisted nutrition:</b> {@html resource.detailMedicallyAssisted}
+          {#if structuredFields.doNotPerformMedicallyAssisted}
+            <b>This includes an order to NOT perform medically assisted nutrition:</b> {@html structuredFields.detailMedicallyAssisted}
           {:else}
-            <b>This includes an order to perform medically assisted nutrition:</b> {@html resource.detailMedicallyAssisted}
+            <b>This includes an order to perform medically assisted nutrition:</b> {@html structuredFields.detailMedicallyAssisted}
           {/if}
         </ol>
       {/if}

--- a/src/lib/components/resource-templates/Observation.svelte
+++ b/src/lib/components/resource-templates/Observation.svelte
@@ -6,7 +6,7 @@
   import { hasChoiceDTField, choiceDTFields } from '$lib/utils/util';
   import CodeableConcept from '$lib/components/resource-templates/CodeableConcept.svelte';
   import Date from '$lib/components/resource-templates/Date.svelte';
-  import { buildObservationSeriesMap, SparklinePoint, sparklineSeriesFor } from '$lib/utils/observationSparkline';
+  import { buildObservationSeriesMap, type SparklinePoint, sparklineSeriesFor } from '$lib/utils/observationSparkline';
   import ObservationSparkline from '$lib/components/app/ObservationSparkline.svelte';
   
   export let content: ResourceTemplateParams<Observation>; // Define a prop to pass the data to the component
@@ -66,7 +66,8 @@
 
   $: {
     if (content.entries) {
-      const observationSeriesMap = buildObservationSeriesMap(content.entries);
+      const resources = content.entries.map((r) => Object.values(r)).flat().map(r => r.rh.resource);
+      const observationSeriesMap = buildObservationSeriesMap(resources);
       sparklineSeries = sparklineSeriesFor(resource, observationSeriesMap);
     }
   }

--- a/src/lib/components/resource-templates/Observation.svelte
+++ b/src/lib/components/resource-templates/Observation.svelte
@@ -6,6 +6,8 @@
   import { hasChoiceDTField, choiceDTFields } from '$lib/utils/util';
   import CodeableConcept from '$lib/components/resource-templates/CodeableConcept.svelte';
   import Date from '$lib/components/resource-templates/Date.svelte';
+  import { buildObservationSeriesMap, SparklinePoint, sparklineSeriesFor } from '$lib/utils/observationSparkline';
+  import ObservationSparkline from '$lib/components/app/ObservationSparkline.svelte';
   
   export let content: ResourceTemplateParams<Observation>; // Define a prop to pass the data to the component
   export let contained: Boolean = false;
@@ -59,59 +61,77 @@
       members = [];
     }
   }
+
+  let sparklineSeries: Array<SparklinePoint> | undefined;
+
+  $: {
+    if (content.entries) {
+      const observationSeriesMap = buildObservationSeriesMap(content.entries);
+      sparklineSeries = sparklineSeriesFor(resource, observationSeriesMap);
+    }
+  }
 </script>
 
-{#if odhResourceCodes.includes(resource.code?.coding?.[0].code ?? "")}
-  <OccupationalData {content} />
-{:else}
-  {#if resource.code}
-    <CodeableConcept codeableConcept={resource.code} />
-  {/if}
-  {#if resource.valueCodeableConcept?.coding?.[0].display}
-    {resource.valueCodeableConcept.coding[0].display}<br>
-  {/if}
-  {#if resource.valueQuantity}
-    {resource.valueQuantity.value ?? ""} {resource.valueQuantity.unit ?? ""}<br>
-  {/if}
-  {#if resource.valueString}
-    {resource.valueString ?? ""}<br>
-  {/if}
-  {#if resource.note}
-  {#each resource.note as note}
-    {#if note.text}
-      Note: {note.text}<br>
+<div class="d-flex justify-content-between align-items-center">
+  <div>
+    {#if odhResourceCodes.includes(resource.code?.coding?.[0].code ?? "")}
+      <OccupationalData {content} />
+    {:else}
+      {#if resource.code}
+        <CodeableConcept codeableConcept={resource.code} />
+      {/if}
+      {#if resource.valueCodeableConcept?.coding?.[0].display}
+        {resource.valueCodeableConcept.coding[0].display}<br>
+      {/if}
+      {#if resource.valueQuantity}
+        {resource.valueQuantity.value ?? ""} {resource.valueQuantity.unit ?? ""}<br>
+      {/if}
+      {#if resource.valueString}
+        {resource.valueString ?? ""}<br>
+      {/if}
+      {#if resource.note}
+      {#each resource.note as note}
+        {#if note.text}
+          Note: {note.text}<br>
+        {/if}
+      {/each}
+      {/if}
+      {#if !(resource.valueCodeableConcept || resource.valueQuantity || resource.valueString)}
+        <br>
+      {/if}
+      {#if members.length > 0}
+      <table class="table table-bordered table-sm">
+        <thead>
+          <tr><th>Result(s)</th></tr>
+        </thead>
+        <tbody>
+        {#each members as member}
+          <tr>
+            <td>
+              <div class="mx-4">
+                {#if member.resource}
+                  <svelte:self
+                    content={{ resource: member.resource, entries: content.entries }}
+                    contained={hasChoiceDTField("effective", member.resource)}
+                  />
+                {:else if member.display}
+                  <strong>{member.display}</strong>
+                {/if}
+              </div>
+            </td>
+          </tr>
+        {/each}
+        </tbody>
+      </table>
+      {/if}
+      {#if !contained && hasChoiceDTField("effective", resource)}
+        Date: <Date fields={choiceDTFields("effective", resource)} />
+      {/if}
     {/if}
-  {/each}
+  </div>
+  {#if sparklineSeries}
+    <div class="d-flex justify-content-center align-items-center" style="flex: 0 0 auto; max-width: fit-content">
+      <ObservationSparkline series={sparklineSeries} currentId={resource.id} />
+    </div>
   {/if}
-  {#if !(resource.valueCodeableConcept || resource.valueQuantity || resource.valueString)}
-    <br>
-  {/if}
-  {#if members.length > 0}
-  <table class="table table-bordered table-sm">
-    <thead>
-      <tr><th>Result(s)</th></tr>
-    </thead>
-    <tbody>
-    {#each members as member}
-      <tr>
-        <td>
-          <div class="mx-4">
-            {#if member.resource}
-              <svelte:self
-                content={{ resource: member.resource, entries: content.entries }}
-                contained={hasChoiceDTField("effective", member.resource)}
-              />
-            {:else if member.display}
-              <strong>{member.display}</strong>
-            {/if}
-          </div>
-        </td>
-      </tr>
-    {/each}
-    </tbody>
-  </table>
-  {/if}
-  {#if !contained && hasChoiceDTField("effective", resource)}
-    Date: <Date fields={choiceDTFields("effective", resource)} />
-  {/if}
-{/if}
+</div>

--- a/src/lib/config/config.ts
+++ b/src/lib/config/config.ts
@@ -360,6 +360,7 @@ export const PATIENT_IPS = {
   'Peter Kieth Jordan': 'https://terminz.azurewebsites.net/fhir/Patient/$summary?profile=http://hl7.org/fhir/uv/ips/StructureDefinition/Bundle-uv-ips&identifier=https://standards.digital.health.nz/ns/nhi-id|NNJ9186&_format=json'
 }
 export const EXAMPLE_IPS = {
+  'Betsy QuestionnaireResponses 2026-07 Connectathon': 'https://gw.interop.community/paciosandbox/open/QuestionnaireResponse?patient=patient-betsysmith-johnson01&questionnaire=https://gw.interop.community/paciosandbox/open/Questionnaire/GAD7Questionnaire',
   'Epic $summary Connectathon 2025-05': 'https://connectathon.epic.com/Interconnect-Fhir-Oauth/api/FHIR/R4/Patient/e5ZHnklVuYuT85PnDVOepOg3/$summary',
   'Epic HIMSS': 'https://ihe-nimbus.epic.com/Interconnect-FHIR-Open/api/FHIR/R4/Patient/e1o-b5iIsAPxRiD2Ct8KekQ3/$summary',
   'Maria SEATTLE Gravitate': 'https://fhir.ips-demo.dev.cirg.uw.edu/fhir/Patient/14599/$summary',

--- a/src/lib/config/resource_config.ts
+++ b/src/lib/config/resource_config.ts
@@ -37,7 +37,7 @@ export const RESOURCE_CONFIG: Record<string, any> = {
       sortFields: ['dateTime']
     },
     'Coverage': {
-      category: 'Coverages',
+      category: 'Insurance Policies',
       component: Coverage,
       sortFields: ['period']
     },
@@ -99,7 +99,7 @@ export const RESOURCE_CONFIG: Record<string, any> = {
       sortFields: ['effective', 'dateAsserted']
     },
     'Observation': {
-      category: 'Observations/Results',
+      category: 'Observations and Results',
       component: Observation,
       sortFields: ['effective', 'issued']
     },
@@ -108,7 +108,7 @@ export const RESOURCE_CONFIG: Record<string, any> = {
       component: Organization,
     },
     'Patient': {
-      category: 'Patient',
+      category: 'Patient Data',
       component: Patient,
     },
     'Practitioner': {
@@ -124,5 +124,9 @@ export const RESOURCE_CONFIG: Record<string, any> = {
       category: 'Questionnaires',
       component: QuestionnaireResponse,
       sortFields: ['authored']
+    },
+    'RelatedPerson': {
+      category: 'Family Members',
+      component: Patient,
     }
   };

--- a/src/lib/utils/observationSparkline.ts
+++ b/src/lib/utils/observationSparkline.ts
@@ -1,0 +1,95 @@
+import type { Observation } from 'fhir/r4';
+import { getFHIRDateAndPrecision } from '$lib/utils/util';
+import type { CategorizedResource } from '$lib/stores/categorizedResources';
+
+const ORDINAL_VALUE_URL = 'http://hl7.org/fhir/StructureDefinition/ordinalValue';
+
+// LOINC PHQ/GAD answer-list ordinals, used as a fallback when a coded answer
+// doesn't carry an ordinalValue extension (e.g. GAD-7 "Not at all" ... "Nearly
+// every day").
+const CODED_ANSWER_ORDINALS: Record<string, number> = {
+  'LA6568-5': 0, // Not at all
+  'LA6569-3': 1, // Several days
+  'LA6570-1': 2, // More than half the days
+  'LA6571-9': 3, // Nearly every day
+};
+
+function ordinalFromCoding(coding: any): number | undefined {
+  if (!coding) return undefined;
+  const ext = coding.extension?.find((e: any) => e.url === ORDINAL_VALUE_URL);
+  if (typeof ext?.valueDecimal === 'number') return ext.valueDecimal;
+  if (coding.code && coding.code in CODED_ANSWER_ORDINALS) return CODED_ANSWER_ORDINALS[coding.code];
+  return undefined;
+}
+
+// Best-effort numeric value for plotting an Observation on a sparkline.
+// Returns undefined when no numeric value can be derived (the caller then skips it).
+export function getObservationNumericValue(observation: Observation): number | undefined {
+  if (typeof observation.valueQuantity?.value === 'number') return observation.valueQuantity.value;
+  if (typeof observation.valueInteger === 'number') return observation.valueInteger;
+  if (typeof (observation as any).valueDecimal === 'number') return (observation as any).valueDecimal;
+
+  const cc = observation.valueCodeableConcept;
+  if (cc?.coding) {
+    for (const coding of cc.coding) {
+      const ord = ordinalFromCoding(coding);
+      if (ord !== undefined) return ord;
+    }
+  }
+  const ord = ordinalFromCoding((observation as any).valueCoding);
+  if (ord !== undefined) return ord;
+
+  return undefined;
+}
+
+// Key an Observation by its primary code coding (system|code) so that
+// observations sharing a code group together.
+export function getObservationCodeKey(observation: Observation): string | undefined {
+  const coding = observation.code?.coding?.find(c => c.code);
+  if (!coding?.code) return undefined;
+  return `${coding.system ?? ''}|${coding.code}`;
+}
+
+export interface SparklinePoint {
+  id: string;   // ResourceHelper tempId, used to highlight the current observation
+  y: number;    // numeric value
+  time: number; // effective date in ms, for ordering
+}
+
+// Build a map from code-key to a date-sorted series of numeric points, across
+// all the given (Observation) resources.
+export function buildObservationSeriesMap(
+  resources: CategorizedResource[]
+): Map<string, SparklinePoint[]> {
+  const groups = new Map<string, SparklinePoint[]>();
+  for (const cr of resources) {
+    const resource = cr.rh.resource as Observation;
+    if (resource.resourceType !== 'Observation') continue;
+    const key = getObservationCodeKey(resource);
+    if (!key) continue;
+    const y = getObservationNumericValue(resource);
+    if (y === undefined) continue;
+    const date = getFHIRDateAndPrecision(resource, 'effective');
+    const time = date ? date.date.getTime() : 0;
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key)!.push({ id: cr.rh.tempId, y, time });
+  }
+  for (const series of groups.values()) {
+    series.sort((a, b) => a.time - b.time);
+  }
+  return groups;
+}
+
+// The date-sorted series for a single value, or undefined when there aren't
+// enough shared-code points to draw a meaningful sparkline.
+export function sparklineSeriesFor(
+  value: CategorizedResource,
+  seriesMap: Map<string, SparklinePoint[]>
+): SparklinePoint[] | undefined {
+  const resource = value.rh.resource as Observation;
+  if (resource.resourceType !== 'Observation') return undefined;
+  const key = getObservationCodeKey(resource);
+  if (!key) return undefined;
+  const series = seriesMap.get(key);
+  return series && series.length >= 2 ? series : undefined;
+}

--- a/src/lib/utils/observationSparkline.ts
+++ b/src/lib/utils/observationSparkline.ts
@@ -59,11 +59,10 @@ export interface SparklinePoint {
 // Build a map from code-key to a date-sorted series of numeric points, across
 // all the given (Observation) resources.
 export function buildObservationSeriesMap(
-  resources: CategorizedResource[]
+  resources: Observation[]
 ): Map<string, SparklinePoint[]> {
   const groups = new Map<string, SparklinePoint[]>();
-  for (const cr of resources) {
-    const resource = cr.rh.resource as Observation;
+  for (const resource of resources) {
     if (resource.resourceType !== 'Observation') continue;
     const key = getObservationCodeKey(resource);
     if (!key) continue;
@@ -72,7 +71,7 @@ export function buildObservationSeriesMap(
     const date = getFHIRDateAndPrecision(resource, 'effective');
     const time = date ? date.date.getTime() : 0;
     if (!groups.has(key)) groups.set(key, []);
-    groups.get(key)!.push({ id: cr.rh.tempId, y, time });
+    groups.get(key)!.push({ id: resource.id, y, time });
   }
   for (const series of groups.values()) {
     series.sort((a, b) => a.time - b.time);
@@ -83,10 +82,9 @@ export function buildObservationSeriesMap(
 // The date-sorted series for a single value, or undefined when there aren't
 // enough shared-code points to draw a meaningful sparkline.
 export function sparklineSeriesFor(
-  value: CategorizedResource,
+  resource: Observation,
   seriesMap: Map<string, SparklinePoint[]>
 ): SparklinePoint[] | undefined {
-  const resource = value.rh.resource as Observation;
   if (resource.resourceType !== 'Observation') return undefined;
   const key = getObservationCodeKey(resource);
   if (!key) return undefined;

--- a/src/lib/utils/observationSparkline.ts
+++ b/src/lib/utils/observationSparkline.ts
@@ -1,6 +1,5 @@
-import type { Observation } from 'fhir/r4';
+import type { Observation, Resource } from 'fhir/r4';
 import { getFHIRDateAndPrecision } from '$lib/utils/util';
-import type { CategorizedResource } from '$lib/stores/categorizedResources';
 
 const ORDINAL_VALUE_URL = 'http://hl7.org/fhir/StructureDefinition/ordinalValue';
 
@@ -59,7 +58,7 @@ export interface SparklinePoint {
 // Build a map from code-key to a date-sorted series of numeric points, across
 // all the given (Observation) resources.
 export function buildObservationSeriesMap(
-  resources: Observation[]
+  resources: Resource[]
 ): Map<string, SparklinePoint[]> {
   const groups = new Map<string, SparklinePoint[]>();
   for (const resource of resources) {

--- a/src/lib/utils/resourceUploader.js
+++ b/src/lib/utils/resourceUploader.js
@@ -1,8 +1,18 @@
 import { INTERMEDIATE_FHIR_SERVER_BASE } from '$lib/config/config';
+import { extractResourcesFromQuestionnaireResponse } from '$lib/utils/sdcClient';
 
 // Create Bundle and POST
 export async function uploadResources(resources, token=undefined) {
     let entries = [];
+
+    // Before POSTing, run $extract on each QuestionnaireResponse (which isn't in
+    // the FHIR server yet) and fold the extracted resources into the bundle.
+    let questionnaireResponses = resources.filter(resource => resource.resourceType === "QuestionnaireResponse");
+    let extractedResources = (await Promise.all(
+        questionnaireResponses.map(qr => extractResourcesFromQuestionnaireResponse(qr, token))
+    )).flat();
+    resources = [...resources, ...extractedResources];
+
     resources.forEach(resource => {
         if (!resource.id) {
             resource.id = crypto.randomUUID();

--- a/src/lib/utils/resourceUploader.js
+++ b/src/lib/utils/resourceUploader.js
@@ -5,13 +5,17 @@ import { extractResourcesFromQuestionnaireResponse } from '$lib/utils/sdcClient'
 export async function uploadResources(resources, token=undefined) {
     let entries = [];
 
-    // Before POSTing, run $extract on each QuestionnaireResponse (which isn't in
+    // Before POSTing, try running $extract on each QuestionnaireResponse (which isn't in
     // the FHIR server yet) and fold the extracted resources into the bundle.
-    let questionnaireResponses = resources.filter(resource => resource.resourceType === "QuestionnaireResponse");
-    let extractedResources = (await Promise.all(
-        questionnaireResponses.map(qr => extractResourcesFromQuestionnaireResponse(qr, token))
-    )).flat();
-    resources = [...resources, ...extractedResources];
+    try {
+        let questionnaireResponses = resources.filter(resource => resource.resourceType === "QuestionnaireResponse");
+        let extractedResources = (await Promise.all(
+            questionnaireResponses.map(qr => extractResourcesFromQuestionnaireResponse(qr, token))
+        )).flat();
+        resources = [...resources, ...extractedResources];
+    } catch (error) {
+        console.error(error);
+    }
 
     resources.forEach(resource => {
         if (!resource.id) {

--- a/src/lib/utils/sdcClient.js
+++ b/src/lib/utils/sdcClient.js
@@ -1,0 +1,49 @@
+import { INTERMEDIATE_FHIR_SERVER_BASE } from '$lib/config/config';
+
+// Run the SDC $extract operation on a QuestionnaireResponse that hasn't been
+// persisted yet, and return the resources (e.g. Observations) it extracts.
+export async function extractResourcesFromQuestionnaireResponse(questionnaireResponse, token=undefined) {
+    let headers = {
+        'Content-Type': 'application/json+fhir',
+    };
+    if (token) {
+        headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    let response = await fetch(`${INTERMEDIATE_FHIR_SERVER_BASE}/QuestionnaireResponse/$extract`, {
+        method: 'POST',
+        headers,
+        // Pass the QR inline since it isn't in the FHIR server yet.
+        body: JSON.stringify(questionnaireResponse),
+    });
+
+    let body = await response.text();
+    let parsedBody;
+    try {
+        parsedBody = JSON.parse(body);
+    } catch (error) {
+        console.log(error);
+        console.log("$extract response body:", body);
+        return [];
+    }
+
+    if (!response.ok) {
+        console.error("$extract failed for QuestionnaireResponse", questionnaireResponse.id, parsedBody);
+        return [];
+    }
+
+    // $extract returns a Bundle of the extracted resources.
+    let extracted = (parsedBody?.entry ?? [])
+        .map(entry => entry.resource)
+        .filter(Boolean);
+
+    // Each extracted resource needs an id so it can be referenced via a
+    // urn:uuid fullUrl in a transaction bundle.
+    extracted.forEach(resource => {
+        if (!resource.id) {
+            resource.id = crypto.randomUUID();
+        }
+    });
+
+    return extracted;
+}

--- a/src/lib/utils/sdcClient.js
+++ b/src/lib/utils/sdcClient.js
@@ -1,5 +1,48 @@
 import { INTERMEDIATE_FHIR_SERVER_BASE } from '$lib/config/config';
 
+// GAD7 QuestionnaireResponses coming from these sources point at Questionnaire
+// canonicals our $extract can't process. Repoint them to the integer-total
+// variant (which our server knows how to $extract).
+const GAD7_SOURCE_QUESTIONNAIRE_URLS = [
+    "https://gw.interop.community/paciosandbox/open/Questionnaire/GAD7Questionnaire",
+    "http://example.org/fhir/Questionnaire/GAD7Questionnaire",
+];
+const GAD7_TARGET_QUESTIONNAIRE_URL = "https://cirg.uw.edu/Questionnaire/GAD7Questionnaire.integer-total";
+
+// Recursively convert the total-score item's decimal answers to integer answers.
+function convertTotalScoreAnswersToInteger(items) {
+    if (!Array.isArray(items)) return;
+    items.forEach(item => {
+        if (item.linkId === "total-score" && Array.isArray(item.answer)) {
+            item.answer.forEach(answer => {
+                if (answer.valueDecimal !== undefined) {
+                    // These totals are always integers, so rounding is lossless.
+                    answer.valueInteger = Math.round(answer.valueDecimal);
+                    delete answer.valueDecimal;
+                }
+            });
+        }
+        // total-score may live under nested items.
+        convertTotalScoreAnswersToInteger(item.item);
+    });
+}
+
+// Normalize GAD7 QuestionnaireResponses so they can be run through $extract.
+// Mutates and returns the given resources array.
+export function normalizeGad7QuestionnaireResponses(resources) {
+    if (!Array.isArray(resources)) return resources;
+    resources.forEach(resource => {
+        if (resource?.resourceType !== "QuestionnaireResponse") return;
+        if (!GAD7_SOURCE_QUESTIONNAIRE_URLS.includes(resource.questionnaire)) return;
+
+        // 1. Repoint the questionnaire canonical.
+        resource.questionnaire = GAD7_TARGET_QUESTIONNAIRE_URL;
+        // 2. Convert the total-score answer from valueDecimal to valueInteger.
+        convertTotalScoreAnswersToInteger(resource.item);
+    });
+    return resources;
+}
+
 // Run the SDC $extract operation on a QuestionnaireResponse that hasn't been
 // persisted yet, and return the resources (e.g. Observations) it extracts.
 export async function extractResourcesFromQuestionnaireResponse(questionnaireResponse, token=undefined) {

--- a/src/lib/utils/sdcClient.js
+++ b/src/lib/utils/sdcClient.js
@@ -3,6 +3,7 @@ import { INTERMEDIATE_FHIR_SERVER_BASE } from '$lib/config/config';
 // GAD7 QuestionnaireResponses coming from these sources point at Questionnaire
 // canonicals our $extract can't process. Repoint them to the integer-total
 // variant (which our server knows how to $extract).
+// NOTE: This addressed a special case in the 2026-07 Connectathon.
 const GAD7_SOURCE_QUESTIONNAIRE_URLS = [
     "https://gw.interop.community/paciosandbox/open/Questionnaire/GAD7Questionnaire",
     "http://example.org/fhir/Questionnaire/GAD7Questionnaire",
@@ -10,6 +11,7 @@ const GAD7_SOURCE_QUESTIONNAIRE_URLS = [
 const GAD7_TARGET_QUESTIONNAIRE_URL = "https://cirg.uw.edu/Questionnaire/GAD7Questionnaire.integer-total";
 
 // Recursively convert the total-score item's decimal answers to integer answers.
+// NOTE: This addressed a special case in the 2026-07 Connectathon.
 function convertTotalScoreAnswersToInteger(items) {
     if (!Array.isArray(items)) return;
     items.forEach(item => {
@@ -29,6 +31,7 @@ function convertTotalScoreAnswersToInteger(items) {
 
 // Normalize GAD7 QuestionnaireResponses so they can be run through $extract.
 // Mutates and returns the given resources array.
+// NOTE: This addressed a special case in the 2026-07 Connectathon.
 export function normalizeGad7QuestionnaireResponses(resources) {
     if (!Array.isArray(resources)) return resources;
     resources.forEach(resource => {
@@ -45,6 +48,9 @@ export function normalizeGad7QuestionnaireResponses(resources) {
 
 // Run the SDC $extract operation on a QuestionnaireResponse that hasn't been
 // persisted yet, and return the resources (e.g. Observations) it extracts.
+// **Unlike most of the other code in this file, this function is generalized**
+// and should be functional if the Questionnaire has SDC $extract metadata defined 
+// (see example at https://github.com/uwcirg/fhir-questionnaires/blob/main/GAD-7.cthon.2026-07.pacio.integer-total.json).
 export async function extractResourcesFromQuestionnaireResponse(questionnaireResponse, token=undefined) {
     let headers = {
         'Content-Type': 'application/json+fhir',


### PR DESCRIPTION
1. Addresses AD import and processing issues as discovered during the cthon.
2. Adds new capacity to perform SDC (Structured Data Capture) QuestionnaireResponse $extract to create Observations from QR's. This is "[Observation-based extraction](https://hl7.org/fhir/uv/sdc/en/extraction.html#observation-based-extraction)", which is supported by Hapi. After a QR is retrieved\*, [before being uploaded to Hapi](https://github.com/uwcirg/shl-ips/pull/168/changes#diff-3433f149003b182750c56072b707125878b72ed923b4f32b2cfd0767842d099aR10) the code now calls a new [extractResourcesFromQuestionnaireResponse function](https://github.com/uwcirg/shl-ips/pull/168/changes#diff-ba80cee3f1d6dd2f511c1348d1c5d4a6c92241498e4c664e31e3215eeb384a5aR54).  That function looks for the corresponding Questionnaire in Hapi (note: per SDC the match is QR.questionnaire to [Questionnaire.ur](https://github.com/uwcirg/fhir-questionnaires/pull/45/changes#diff-037f46b1a7f7fd802df4ad41a128b0d9c5a5447d51689dcb0f6249c3cc95e79cR674)l), and if the Questionnaire defines SDC metadata, then extraction is performed, and the resulting Observation(s) are also persisted to Hapi (along w/ the QR). This extraction process is generalized - will work for other Questionnaires that have extract defined. See the Questionnaire that we used at https://github.com/uwcirg/fhir-questionnaires/blob/main/GAD-7.cthon.2026-07.pacio.integer-total.json (provided by the PACIO team, and then I modified it to add SDC metadata).
3. At the view of Observations, [if the Observation has a numerical component](https://github.com/uwcirg/shl-ips/pull/168/changes#diff-e629f1927d1df72e62e615aa8317d59cbd3df17b94033c29ab7a0628473e3984R27), sparklines for longitudinal data for that code are displayed (see screenshot below).

\* Note that this Connectathon's QR processing needed a carve-out to change a QR data type, and to re-map QR.questionnaire to refer to the copy in our server to which I'd added $extract metadata. @daniellrgn I have commented out this carve-out, and added comments to the one-off functions to clarify at [src/lib/utils/sdcClient.js](https://github.com/uwcirg/shl-ips/pull/168#diff-ba80cee3f1d6dd2f511c1348d1c5d4a6c92241498e4c664e31e3215eeb384a5aR35).

See Justin's notes at [PACIO Quality Measures + IG Testing](https://docs.google.com/document/d/1D3dUFf-S2WQkZB54PeeGidkICpvYWbuDxRPDn1vN0Ac/edit?tab=t.0#heading=h.sobvu5n4g3kd) 

<img width="812" height="965" alt="image" src="https://github.com/user-attachments/assets/f138bff3-d9e8-489c-b24f-bfe414c53478" />
