### PR TITLE
At /data/manage/Observations%20and%20Results, add sparklines for each Observation

### DIFF
--- a/src/lib/components/app/DataSummary.svelte
+++ b/src/lib/components/app/DataSummary.svelte
@@ -15,6 +15,8 @@
   import {getFriendlySourceNameBySource} from '$lib/utils/resourceCollectionUtils';
   import { createCategorizedStore, type CategoryMap } from '$lib/stores/categorizedResources';
   import ResourceDisplay from '$lib/components/app/ResourceDisplay.svelte';
+  import ObservationSparkline from '$lib/components/app/ObservationSparkline.svelte';
+  import { buildObservationSeriesMap, sparklineSeriesFor } from '$lib/utils/observationSparkline';
   import { derived, type Readable } from 'svelte/store';
   import { goto } from '$app/navigation';
 
@@ -104,6 +106,7 @@
     {#if $categoryDataToDisplay[category] && Object.keys($categoryDataToDisplay[category]).length > 0}
       {@const values = Object.values($categoryDataToDisplay[category]).sort((a, b) => sortResources(a, b))}
       {@const valuesToDisplay = summary ? values.slice(0, 3) : values}
+      {@const observationSeriesMap = buildObservationSeriesMap(values)}
       <CategoryView
         class="mb-4"
         title={category}
@@ -126,6 +129,12 @@
               <Col class="ps-0 overflow-auto justify-content-center align-items-center">
                 <ResourceDisplay resource={value} entries={Object.values($categoryDataToDisplay)} />
               </Col>
+              {@const sparklineSeries = sparklineSeriesFor(value, observationSeriesMap)}
+              {#if sparklineSeries}
+                <Col class="d-flex justify-content-center align-items-center" style="flex: 0 0 auto; max-width: fit-content">
+                  <ObservationSparkline series={sparklineSeries} currentId={value.rh.tempId} />
+                </Col>
+              {/if}
               <Col class="d-flex justify-content-end align-items-center" style="max-width: fit-content">
                 {#if $mode === 'advanced'}
                   <Button

--- a/src/lib/components/app/ObservationSparkline.svelte
+++ b/src/lib/components/app/ObservationSparkline.svelte
@@ -1,0 +1,55 @@
+<script lang="ts">
+  import type { SparklinePoint } from '$lib/utils/observationSparkline';
+
+  export let series: SparklinePoint[] = [];
+  export let currentId: string;
+
+  const width = 120;
+  const height = 32;
+  const padX = 5;
+  const padY = 6;
+
+  $: n = series.length;
+  $: ys = series.map(p => p.y);
+  $: minY = ys.length ? Math.min(...ys) : 0;
+  $: maxY = ys.length ? Math.max(...ys) : 0;
+  $: span = maxY - minY;
+
+  function xFor(i: number): number {
+    if (n <= 1) return width / 2;
+    return padX + (i * (width - 2 * padX)) / (n - 1);
+  }
+  // Higher value -> higher on the chart (smaller pixel y). Flat series centers.
+  function yFor(v: number): number {
+    if (span === 0) return height / 2;
+    return height - padY - ((v - minY) / span) * (height - 2 * padY);
+  }
+
+  $: linePoints = series.map((p, i) => `${xFor(i)},${yFor(p.y)}`).join(' ');
+</script>
+
+{#if n >= 2}
+  <svg
+    {width}
+    {height}
+    viewBox={`0 0 ${width} ${height}`}
+    role="img"
+    aria-label="Trend of values sharing this code"
+  >
+    <polyline
+      points={linePoints}
+      fill="none"
+      stroke="#6c757d"
+      stroke-width="1.5"
+      stroke-linejoin="round"
+      stroke-linecap="round"
+    />
+    {#each series as p, i}
+      {#if p.id === currentId}
+        <circle cx={xFor(i)} cy={yFor(p.y)} r="3.5" fill="#fd7e14" stroke="#fff" stroke-width="1" />
+      {:else}
+        <circle cx={xFor(i)} cy={yFor(p.y)} r="1.6" fill="#6c757d" />
+      {/if}
+    {/each}
+  </svg>
+{/if}

--- a/src/lib/utils/observationSparkline.ts
+++ b/src/lib/utils/observationSparkline.ts
@@ -1,0 +1,95 @@
+import type { Observation } from 'fhir/r4';
+import { getFHIRDateAndPrecision } from '$lib/utils/util';
+import type { CategorizedResource } from '$lib/stores/categorizedResources';
+
+const ORDINAL_VALUE_URL = 'http://hl7.org/fhir/StructureDefinition/ordinalValue';
+
+// LOINC PHQ/GAD answer-list ordinals, used as a fallback when a coded answer
+// doesn't carry an ordinalValue extension (e.g. GAD-7 "Not at all" ... "Nearly
+// every day").
+const CODED_ANSWER_ORDINALS: Record<string, number> = {
+  'LA6568-5': 0, // Not at all
+  'LA6569-3': 1, // Several days
+  'LA6570-1': 2, // More than half the days
+  'LA6571-9': 3, // Nearly every day
+};
+
+function ordinalFromCoding(coding: any): number | undefined {
+  if (!coding) return undefined;
+  const ext = coding.extension?.find((e: any) => e.url === ORDINAL_VALUE_URL);
+  if (typeof ext?.valueDecimal === 'number') return ext.valueDecimal;
+  if (coding.code && coding.code in CODED_ANSWER_ORDINALS) return CODED_ANSWER_ORDINALS[coding.code];
+  return undefined;
+}
+
+// Best-effort numeric value for plotting an Observation on a sparkline.
+// Returns undefined when no numeric value can be derived (the caller then skips it).
+export function getObservationNumericValue(observation: Observation): number | undefined {
+  if (typeof observation.valueQuantity?.value === 'number') return observation.valueQuantity.value;
+  if (typeof observation.valueInteger === 'number') return observation.valueInteger;
+  if (typeof (observation as any).valueDecimal === 'number') return (observation as any).valueDecimal;
+
+  const cc = observation.valueCodeableConcept;
+  if (cc?.coding) {
+    for (const coding of cc.coding) {
+      const ord = ordinalFromCoding(coding);
+      if (ord !== undefined) return ord;
+    }
+  }
+  const ord = ordinalFromCoding((observation as any).valueCoding);
+  if (ord !== undefined) return ord;
+
+  return undefined;
+}
+
+// Key an Observation by its primary code coding (system|code) so that
+// observations sharing a code group together.
+export function getObservationCodeKey(observation: Observation): string | undefined {
+  const coding = observation.code?.coding?.find(c => c.code);
+  if (!coding?.code) return undefined;
+  return `${coding.system ?? ''}|${coding.code}`;
+}
+
+export interface SparklinePoint {
+  id: string;   // ResourceHelper tempId, used to highlight the current observation
+  y: number;    // numeric value
+  time: number; // effective date in ms, for ordering
+}
+
+// Build a map from code-key to a date-sorted series of numeric points, across
+// all the given (Observation) resources.
+export function buildObservationSeriesMap(
+  resources: CategorizedResource[]
+): Map<string, SparklinePoint[]> {
+  const groups = new Map<string, SparklinePoint[]>();
+  for (const cr of resources) {
+    const resource = cr.rh.resource as Observation;
+    if (resource.resourceType !== 'Observation') continue;
+    const key = getObservationCodeKey(resource);
+    if (!key) continue;
+    const y = getObservationNumericValue(resource);
+    if (y === undefined) continue;
+    const date = getFHIRDateAndPrecision(resource, 'effective');
+    const time = date ? date.date.getTime() : 0;
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key)!.push({ id: cr.rh.tempId, y, time });
+  }
+  for (const series of groups.values()) {
+    series.sort((a, b) => a.time - b.time);
+  }
+  return groups;
+}
+
+// The date-sorted series for a single value, or undefined when there aren't
+// enough shared-code points to draw a meaningful sparkline.
+export function sparklineSeriesFor(
+  value: CategorizedResource,
+  seriesMap: Map<string, SparklinePoint[]>
+): SparklinePoint[] | undefined {
+  const resource = value.rh.resource as Observation;
+  if (resource.resourceType !== 'Observation') return undefined;
+  const key = getObservationCodeKey(resource);
+  if (!key) return undefined;
+  const series = seriesMap.get(key);
+  return series && series.length >= 2 ? series : undefined;
+}


### PR DESCRIPTION
At /data/manage/Observations%20and%20Results, add sparklines for each Observation line item. 

The sparklines are populated by all the Observatations that share the same code.coding[].code. Includes an orange indication of where the point for this Observatation lands. To clarify, there will likely be ~5 Observatations that share the same code, so they'd each have the same sparkline, but a different point highlighted in orange.