### PR TITLE
Fix patient-provided resource form saving

### DIFF
--- a/src/lib/components/app/ODHForm.svelte
+++ b/src/lib/components/app/ODHForm.svelte
@@ -7,7 +7,7 @@
   import { METHODS, CATEGORIES } from '$lib/config/tags';
   import { ResourceHelper } from '$lib/utils/ResourceHelper';
   import type { Observation } from 'fhir/r4';
-  import { copyOf } from '$lib/utils/util';
+  import { copyOf, getUniqueResourceObject } from '$lib/utils/util';
 
   export let formData: IResourceCollection | undefined;
   export let processing: boolean = false;
@@ -503,7 +503,7 @@
     if (!values.isWorking) { return currentJobResources; } // Don't add current job data if not working
     const uniqueJobs = deduplicateObjectList(values.currentWork);
     for (const [i, jobValue] of uniqueJobs.entries()) {
-      const currentJobResource = JSON.parse(JSON.stringify(currentJobTemplate));
+      const currentJobResource = getUniqueResourceObject(currentJobTemplate);
       currentJobResource.id = `odh-current-job-${i}`;
       if (jobValue.start) {
         let period: any = { start: jobValue.start };
@@ -532,7 +532,7 @@
     const pastJobResources: Observation[] = [];
     const uniqueJobs = deduplicateObjectList(values.pastWork);
     for (const [i, jobValue] of uniqueJobs.entries()) {
-      const pastJobResource = JSON.parse(JSON.stringify(pastJobTemplate));
+      const pastJobResource = getUniqueResourceObject(pastJobTemplate);
       pastJobResource.id = `odh-past-job-${i}`;
       if (jobValue.start || jobValue.end) {
         let period: any = {};
@@ -568,7 +568,7 @@
     const uniqueRetirementDates = deduplicateObjectList(values.retirementDates);
     const validRetirementDates = uniqueRetirementDates.filter((retirementDate: any) => retirementDate.start);
     for (const [i, retirementDate] of validRetirementDates.entries()) {
-      const retirementDateResource = JSON.parse(JSON.stringify(retirementDateTemplate));
+      const retirementDateResource = getUniqueResourceObject(retirementDateTemplate);
       retirementDateResource.id = `odh-retirement-date-${i}`;
       if (retirementDate.start) {
         retirementDateResource.valueDateTime = retirementDate.start;
@@ -583,7 +583,7 @@
     const uniqueCombatPeriods = deduplicateObjectList(values.combatPeriods);
     const validCombatPeriods = uniqueCombatPeriods.filter((combatPeriod: any) => combatPeriod.start || combatPeriod.end);
     for (const [i, combatPeriod] of validCombatPeriods.entries()) {
-      const combatPeriodResource = JSON.parse(JSON.stringify(combatPeriodTemplate));
+      const combatPeriodResource = getUniqueResourceObject(combatPeriodTemplate);
       combatPeriodResource.id = `odh-combat-period-${i}`;
       if (combatPeriod.start || combatPeriod.end) {
         let period: any = {};
@@ -601,7 +601,7 @@
   }
 
   function generateEmploymentStatusResources(): Observation[] {
-    const employmentStatusResource = JSON.parse(JSON.stringify(employmentStatusTemplate));
+    const employmentStatusResource = getUniqueResourceObject(employmentStatusTemplate);
     employmentStatusResource.id = `odh-employment-status`;
     employmentStatusResource.valueCodeableConcept.coding[0].code = statuses[values.status];
     employmentStatusResource.valueCodeableConcept.coding[0].display = values.status;

--- a/src/lib/components/app/PatientBody.svelte
+++ b/src/lib/components/app/PatientBody.svelte
@@ -15,7 +15,7 @@
   import FHIRDataServiceChecker from '$lib/components/app/FHIRDataServiceChecker.svelte';
   import { METHODS, CATEGORIES } from '$lib/config/tags';
   import { ResourceHelper } from '$lib/utils/ResourceHelper';
-  import { copyOf } from '$lib/utils/util';
+  import { copyOf, getUniqueResourceObject } from '$lib/utils/util';
 
   export let disabled = false;
   export let formData: IResourceCollection | undefined;
@@ -466,7 +466,7 @@
 
   function prepareConditionResource(entry: BodyConcernEntry) {
     if (entry.bodyPart === '' && entry.concern === '') return;
-    let currentCondition = JSON.parse(JSON.stringify(conditionTemplate));
+    let currentCondition = getUniqueResourceObject(conditionTemplate);
     currentCondition.code.text = entry.concern;
     currentCondition.bodySite.coding.push(bodyPartOptions[entry.bodyPart][entry.side]);
     currentCondition.recordedDate = new Date().toISOString().slice(0, 10);;

--- a/src/lib/components/app/PatientInfo.svelte
+++ b/src/lib/components/app/PatientInfo.svelte
@@ -9,7 +9,7 @@
     Spinner
   } from '@sveltestrap/sveltestrap';
   import { createEventDispatcher } from 'svelte';
-  import { constructPatientResource } from '$lib/utils/util';
+  import { constructPatientResource, copyOf } from '$lib/utils/util';
   import GenderInput from '$lib/components/form/GenderInput.svelte';
   import CountryInput from '$lib/components/form/CountryInput.svelte';
   import ReligionCodeInput from '$lib/components/form/ReligionCodeInput.svelte';
@@ -34,7 +34,7 @@
   let FHIRDataServiceCheckerInstance: FHIRDataServiceChecker | undefined;
 
   let myPatient;
-  $: myPatient = JSON.parse(JSON.stringify(patient));
+  $: myPatient = copyOf(patient);
   $: {
     if (myPatient) {
       first = myPatient.name?.[0].given?.[0] ?? '';

--- a/src/lib/components/app/PatientMedical.svelte
+++ b/src/lib/components/app/PatientMedical.svelte
@@ -14,7 +14,7 @@
   import FHIRDataServiceChecker from '$lib/components/app/FHIRDataServiceChecker.svelte';
   import { METHODS, CATEGORIES } from '$lib/config/tags';
   import { ResourceHelper } from '$lib/utils/ResourceHelper';
-  import { copyOf } from '$lib/utils/util';
+  import { copyOf, getUniqueResourceObject } from '$lib/utils/util';
 
   export let disabled = false;
   export let formData: IResourceCollection | undefined;
@@ -226,7 +226,7 @@
 
   function prepareProblemResource(entry: HealthHistoryEntry) {
     if (entry.name === '' && entry.detail === '') return;
-    let currentCondition = JSON.parse(JSON.stringify(currentConditionTemplate));
+    let currentCondition = getUniqueResourceObject(currentConditionTemplate);
     currentCondition.code.text = entry.name;
     currentCondition.severity.coding.push(issueSeverityOptions[entry.detail]);
     currentCondition.severity.text = entry.detail;
@@ -236,7 +236,7 @@
 
   function prepareMedicationResource(entry: HealthHistoryEntry) {
     if (entry.name === '' && entry.detail === '') return;
-    let medication = JSON.parse(JSON.stringify(medicationTemplate));
+    let medication = getUniqueResourceObject(medicationTemplate);
     medication.medicationCodeableConcept.text = entry.name;
     medication.dosage[0].text = entry.detail;
     medication.effectiveDateTime = new Date().toISOString().slice(0, 10);
@@ -245,7 +245,7 @@
 
   function prepareHistoryResource(entry: HealthHistoryEntry) {
     if (entry.name === '' && entry.detail === '') return;
-    let pastCondition = JSON.parse(JSON.stringify(pastConditionTemplate));
+    let pastCondition = getUniqueResourceObject(pastConditionTemplate);
     pastCondition.code.text = entry.name;
     pastCondition.onsetString = entry.detail;
     pastCondition.recordedDate = new Date().toISOString().slice(0, 10);

--- a/src/lib/components/app/PatientNeeds.svelte
+++ b/src/lib/components/app/PatientNeeds.svelte
@@ -14,7 +14,7 @@
   import FHIRDataServiceChecker from '$lib/components/app/FHIRDataServiceChecker.svelte';
   import { METHODS, CATEGORIES } from '$lib/config/tags';
   import { ResourceHelper } from '$lib/utils/ResourceHelper';
-  import { copyOf } from '$lib/utils/util';
+  import { copyOf, getUniqueResourceObject } from '$lib/utils/util';
   
   export let disabled = false;
   export let formData: IResourceCollection | undefined;
@@ -291,7 +291,7 @@
   }
 
   function prepareConditionResource(conditionOption: ConditionOption) {
-    let condition = JSON.parse(JSON.stringify(conditionTemplate));
+    let condition = getUniqueResourceObject(conditionTemplate);
     condition.code.coding.push(conditionOption.code);
     condition.recordedDate = new Date().toISOString().slice(0, 10);
     return condition;
@@ -300,7 +300,7 @@
   function prepareIps() {
     const resources = Object.values(conditions).filter(c => c.checked).map(prepareConditionResource);
     if (additionalInfo.trim() !== '') {
-      let infoCondition = JSON.parse(JSON.stringify(conditionTemplate));
+      let infoCondition = getUniqueResourceObject(conditionTemplate);
       infoCondition.code.text = additionalInfo;
       infoCondition.recordedDate = new Date().toISOString().slice(0, 10);
       resources.push(infoCondition);

--- a/src/lib/components/app/PatientStory.svelte
+++ b/src/lib/components/app/PatientStory.svelte
@@ -15,7 +15,7 @@
   import FHIRDataServiceChecker from '$lib/components/app/FHIRDataServiceChecker.svelte';
   import { METHODS, CATEGORIES } from '$lib/config/tags';
   import { ResourceHelper } from '$lib/utils/ResourceHelper';
-  import { copyOf } from '$lib/utils/util';
+  import { copyOf, getUniqueResourceObject } from '$lib/utils/util';
 
   export let disabled = false;
   export let formData: IResourceCollection | undefined;
@@ -168,7 +168,7 @@
     if (!goal.value) {
       return;
     }
-    let goalResource = JSON.parse(JSON.stringify(goalResourceTemplate));
+    let goalResource = getUniqueResourceObject(goalResourceTemplate);
     goalResource.statusDate = new Date().toISOString().slice(0, 10);
     goalResource.description.text = goal.value;
     goalResource.achievementStatus.coding[0] = progressCodings[goal.checked ? "in-progress" : "not-achieved"];
@@ -179,7 +179,7 @@
     if (!values.story) {
       return;
     }
-    let observationResource = JSON.parse(JSON.stringify(observationResourceTemplate));
+    let observationResource = getUniqueResourceObject(observationResourceTemplate);
     observationResource.valueString = values.story;
     return observationResource;
   }

--- a/src/lib/utils/resourceUploader.js
+++ b/src/lib/utils/resourceUploader.js
@@ -4,6 +4,10 @@ import { INTERMEDIATE_FHIR_SERVER_BASE } from '$lib/config/config';
 export async function uploadResources(resources, token=undefined) {
     let entries = [];
     resources.forEach(resource => {
+        if (!resource.id) {
+            resource.id = crypto.randomUUID();
+            console.warn("Resource has no id, generated random uuid for upload", resource);
+        }
         let entry = {
             request: {
                 // method: resource.resourceType === "Patient" ? "PUT" : "POST",

--- a/src/lib/utils/util.ts
+++ b/src/lib/utils/util.ts
@@ -21,6 +21,12 @@ export function copyOf(a: any) {
   return JSON.parse(JSON.stringify(a));
 }
 
+export function getUniqueResourceObject(template: Resource) {
+  const resource = JSON.parse(JSON.stringify(template));
+  resource.id = crypto.randomUUID();
+  return resource;
+}
+
 const DATE_PRECISION = {
   "time": 4,
   "day": 3,


### PR DESCRIPTION
Add resource copy function that sets new id, and use across data input forms that rely on templates

If those templates didn't include an id, the uploader would fail to generate a valid fullUrl for the bundle entry.
Added id-generating copy function
Used function where templates are used
Generate id in upload function with warning